### PR TITLE
Fix CSV data extraction for GitHub profile and skills information

### DIFF
--- a/transform.py
+++ b/transform.py
@@ -657,11 +657,21 @@ def transform_evaluation_response(
 
     # Extract GitHub data
     if github_data:
-        csv_row["github_repos"] = github_data.get("public_repos", 0)
-        csv_row["github_followers"] = github_data.get("followers", 0)
-        csv_row["github_following"] = github_data.get("following", 0)
-        csv_row["github_created_at"] = github_data.get("created_at", "")
-        csv_row["github_bio"] = github_data.get("bio", "")
+        # Check if github_data has a nested 'profile' structure
+        if 'profile' in github_data:
+            profile = github_data['profile']
+            csv_row['github_repos'] = profile.get('public_repos', 0)
+            csv_row['github_followers'] = profile.get('followers', 0)
+            csv_row['github_following'] = profile.get('following', 0)
+            csv_row['github_created_at'] = profile.get('created_at', '')
+            csv_row['github_bio'] = profile.get('bio', '')
+        else:
+            # Fallback to direct access if no 'profile' key
+            csv_row['github_repos'] = github_data.get('public_repos', 0)
+            csv_row['github_followers'] = github_data.get('followers', 0)
+            csv_row['github_following'] = github_data.get('following', 0)
+            csv_row['github_created_at'] = github_data.get('created_at', '')
+            csv_row['github_bio'] = github_data.get('bio', '')
     else:
         csv_row["github_repos"] = 0
         csv_row["github_followers"] = 0


### PR DESCRIPTION
### Summary
Fixes the data extraction logic in `transform_evaluation_response()` to correctly access GitHub profile data from nested structure.

### Changes Made
- Modified `transform_evaluation_response()` function in `transform.py`
- GitHub data now correctly accessed via `github_data['profile']` when available

### Testing
- [x] Verified CSV export includes GitHub data when profile exists
- [x] Tested fallback behavior when GitHub data is missing
- [x] Validated all CSV fields are populated as expected

### Before Fix
<img width="707" height="103" alt="image" src="https://github.com/user-attachments/assets/0b7d36b1-1944-4aaf-8271-74a529f99102" />

### After Fix
<img width="704" height="116" alt="Screenshot 2025-10-02 141302" src="https://github.com/user-attachments/assets/ec23b808-12e9-412e-9d19-e54fa853a450" />


### Related Issue
Fixes issue #14 