### PR TITLE
fix: ollama stream and context length

### DIFF
--- a/models.py
+++ b/models.py
@@ -284,7 +284,25 @@ class OllamaProvider:
         **kwargs
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
-        chat_params = {"model": model, "messages": messages, "options": options or {}}
+
+        ollama_options = options.copy() if options else {}
+
+        # remove steam from ollama options
+        ollama_options.pop("stream", None)
+
+        # Add num_ctx 32K context window to options
+        ollama_options["num_ctx"] = 32768
+
+        # convert to chat params
+        chat_params = {
+            "model": model,
+            "messages": messages,
+            "options": ollama_options,
+        }
+
+        # add it to top level
+        if "stream" in kwargs:
+            chat_params["stream"] = kwargs["stream"]
 
         if "format" in kwargs:
             chat_params["format"] = kwargs["format"]


### PR DESCRIPTION
**Description:**
Previously, the context was getting truncated during local Ollama interactions because the `num_ctx` parameter was not being explicitly set. This update ensures that every chat request now includes a `num_ctx` of 32768, extending the available context window and preventing premature cutoffs.

Additionally, `stream` was sometimes passed inside the `options` dictionary, which is not supported by Ollama as per latest documentation. This change removes `stream` from `ollama_options` and correctly places it at the top level of the chat parameters.