### PR TITLE
fixed basic prompt to not just look for basics section only

### DIFF
--- a/prompts/templates/basics.jinja
+++ b/prompts/templates/basics.jinja
@@ -28,7 +28,7 @@ Return ONLY a JSON object with this structure:
   }
 }
 
-**IMPORTANT**: If there is any About Me or Summary section, add that to the summary section of the basics
+**IMPORTANT**: USE the Personal Details given in the resume 
 
 **CRITICAL**: For profiles section:
 - ONLY extract URLs that are EXPLICITLY present in the resume markdown


### PR DESCRIPTION

resolve some part of section not being captured
the primary reason the basics detail was not being captured because we explicitly told it to look for only about me section which restricts it's search specially for smaller model if we lose up some of he constraints it is able to capture the details properly  
https://github.com/interviewstreet/hiring-agent/issues/18