### PR TITLE
bugfix: ensure deductions.total is always positive before model validation

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -82,6 +82,9 @@ class ResumeEvaluator:
             logger.error(f"🔤 Prompt response: {response_text}")
 
             evaluation_dict = json.loads(response_text)
+            if "deductions" in evaluation_dict and "total" in evaluation_dict["deductions"]:
+                value = evaluation_dict["deductions"]["total"]
+                evaluation_dict["deductions"]["total"] = abs(value)
             evaluation_data = EvaluationData(**evaluation_dict)
 
             return evaluation_data


### PR DESCRIPTION
Fixes #24


## Fix: Clamp `deductions.total` to Positive Value for Pydantic Validation

### Summary

This PR fixes a bug where the LLM could produce a negative value for `deductions.total` in the resume evaluation output, which caused Pydantic validation errors and stopped resume scoring. Now, any negative value is automatically converted to its absolute value before being passed into the `EvaluationData` model, ensuring schema compliance and uninterrupted workflow.

---

### Issue Reference

This addresses [#24](https://github.com/interviewstreet/hiring-agent/issues/24), which describes the failure and error message when the deduction total is negative.

---

### What Has Changed

- **Bugfix:** In `evaluator.py`, `deductions.total` is now clamped to its absolute value (`abs(value)`) before model validation.
- **Result:** Resume evaluation **never fails** due to negative deduction totals, and always produces a valid, schema-compliant output.


---

### Why

- **Negative deduction totals** are not meaningful for the `EvaluationData` schema, which expects positive values.
- Fixes crashes and validation errors caused by the LLM or scoring logic returning a negative sum.
- Enhances resilience and stability of the evaluation workflow.

**Please review—feedback welcome!**
