### PR TITLE
 Fix: Resolve undefined variable in GitHub API error handling

### DIFF
--- a/github.py
+++ b/github.py
@@ -237,11 +237,11 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
             )
             return projects
 
-        elif response.status_code == 404:
+        elif status_code == 404:
             print(f"GitHub user not found: {username}")
             return []
         else:
-            print(f"GitHub API error: {response.status_code} - {response.text}")
+            print(f"GitHub API error (status {status_code}): {repos_data.get('message', 'Unknown error')}")
             return []
 
     except requests.exceptions.RequestException as e:


### PR DESCRIPTION
## Changes Made
- Replaced undefined response variable with existing `status_code` and `repos_data` variables
- Improved error message formatting for non-200 status codes
- Added safe dictionary access for error messages using `.get()`

## Testing
-  Verified with non-existent GitHub user (404)
-  Tested with rate-limited requests
-  Confirmed successful 200 responses work as before

### Before 
Before (would crash)
elif response.status_code == 404:  # NameError: 'response' not defined

### After
After (works correctly)
elif status_code == 404:  # Uses existing variable

## 

Closes Issue - #44 