### PR TITLE
fix: improve skill selection using LLM instead of selecting first 10 from skillsets from resume

### DIFF
--- a/prompts/template_manager.py
+++ b/prompts/template_manager.py
@@ -45,6 +45,7 @@ class TemplateManager:
             "github_project_selection": "github_project_selection.jinja",
             "resume_evaluation_criteria": "resume_evaluation_criteria.jinja",
             "resume_evaluation_system_message": "resume_evaluation_system_message.jinja",
+            "prioritized_skills": "prioritized_skills.jinja",
         }
 
         for section_name, filename in template_files.items():

--- a/prompts/templates/prioritized_skills.jinja
+++ b/prompts/templates/prioritized_skills.jinja
@@ -1,0 +1,31 @@
+You are a technical resume analyst with deep expertise in evaluating skills based on their complexity, specialization, and relevance to software development and engineering roles.
+
+Given the following skills and context from a candidate's resume, identify and prioritize the 10 most important and relevant technical skills that showcase technical complexity and diversity. 
+
+Consider the following factors when ranking the skills:
+1. Technical complexity and advanced nature of the skill
+2. Relevance to the candidate's work experience and projects
+3. Specialized skills that demonstrate depth in a particular area
+4. Skills that appear multiple times across projects or work experience
+
+# ALL AVAILABLE SKILLS
+{{ all_skills | join(", ") }}
+
+# WORK EXPERIENCE CONTEXT
+{{ work_context }}
+
+# PROJECT CONTEXT
+{{ project_context }}
+
+# EDUCATION CONTEXT
+{{ education_context }}
+
+Please provide a JSON response with the following structure:
+```json
+{
+  "prioritized_skills": ["Skill1", "Skill2", "Skill3", "Skill4", "Skill5", "Skill6", "Skill7", "Skill8", "Skill9", "Skill10"],
+  "reasoning": "Brief explanation of why these skills were selected and prioritized"
+}
+```
+
+Note: Focus on technical skills that showcase the candidate's capabilities, prioritizing specialized frameworks, tools, programming languages, and technologies over basic or commonly listed skills.


### PR DESCRIPTION
### Problem Solved

- Earlier, the system naively selected the first 10 skills from a candidate's resume
- This often highlighted basic programming skills (like "C", "Java", "HTML") while missing specialized or more relevant technical skills that appeared later in the list
- Freshers were particularly disadvantaged as their resumes typically list common skills first

### Before Fix
```csv
C, C++, Java, Python, JavaScript, TypeScript, HTML, CSS, XML, Node.js
```

### After Fix
```csv
C/C++, Java, Node.js, Python, Flutter, Firebase, MongoDB, Next.js, Docker, AWS
```

### resolves : #43 