### PR TITLE
feat: PR based open source contribution detection

### DIFF
--- a/github.py
+++ b/github.py
@@ -212,7 +212,7 @@ def fetch_repo_contributors(owner: str, repo_name: str) -> List[Dict]:
 
 def fetch_user_pull_requests(username: str, max_prs: int = 50) -> List[Dict]:
     try:
-        # Search for merged PRs authored by the user
+        # Search for PRs authored by the user
         search_query = f"author:{username} type:pr"
         api_url = "https://api.github.com/search/issues"
         params = {

--- a/github.py
+++ b/github.py
@@ -208,7 +208,7 @@ def fetch_repo_contributors(owner: str, repo_name: str) -> List[Dict]:
 def fetch_user_pull_requests(username: str, max_prs: int = 50) -> List[Dict]:
     try:
         # Search for merged PRs authored by the user
-        search_query = f"author:{username} type:pr is:merged"
+        search_query = f"author:{username} type:pr"
         api_url = "https://api.github.com/search/issues"
         params = {
             "q": search_query,
@@ -273,8 +273,7 @@ def fetch_user_pull_requests(username: str, max_prs: int = 50) -> List[Dict]:
                         "number": pr_number,
                         "title": item.get('title', ''),
                         "state": item.get('state', ''),
-                        "created_at": item.get('created_at'),
-                        "merged_at": item.get('closed_at'),  
+                        "isMerged" : pr_data.get('merged', False) if pr_status == 200 else False,
                         "additions": pr_data.get('additions', 0) if pr_status == 200 else 0,
                         "deletions": pr_data.get('deletions', 0) if pr_status == 200 else 0,
                         "changed_files": pr_data.get('changed_files', 0) if pr_status == 200 else 0,
@@ -304,7 +303,7 @@ def fetch_user_pull_requests(username: str, max_prs: int = 50) -> List[Dict]:
                 print(f"Error processing PR {item.get('html_url', '')}: {e}")
                 continue
         
-        print(f"✅ Found {len(prs)} external pull requests for {username}")
+        print(f"Found {len(prs)} external pull requests for {username}")
         return prs
         
     except Exception as e:

--- a/prompts/templates/github_project_selection.jinja
+++ b/prompts/templates/github_project_selection.jinja
@@ -1,6 +1,10 @@
 You are an expert technical recruiter analyzing GitHub repositories to identify the most impressive and relevant projects for a software engineering position.
 
-**ABSOLUTE REQUIREMENT**: You must ONLY select projects where the author_commit_count is 4 or higher. Projects with 1, 2, or 3 commits indicate minimal involvement and should NEVER be selected.
+The data now includes two types of contributions:
+1. **Owned Repositories** (contribution_type: "owned_repository"): Projects the candidate owns/created
+2. **Pull Request Contributions** (contribution_type: "pull_request"): External contributions to other projects
+
+**ABSOLUTE REQUIREMENT for Owned Repositories**: You must ONLY select projects where the author_commit_count is 4 or higher. Projects with 1, 2, or 3 commits indicate minimal involvement and should NEVER be selected.
 
 Given a list of GitHub repositories, select the TOP 7 most impressive projects that would be most relevant for evaluating a candidate's technical skills and experience.
 
@@ -11,20 +15,29 @@ Given a list of GitHub repositories, select the TOP 7 most impressive projects t
 - Look for repositories that are forks of popular projects where the candidate has made meaningful contributions
 - Consider the impact and reach of the project, not just the size of the contribution
 
+**IMPORTANT: Enhanced Open Source Detection**
+- Projects now have enhanced `project_type` classification using license detection and program participation
+- Look for `opensource_program` field indicating participation in Hacktoberfest, GSSoC, GSoC, etc.
+- All external pull requests are automatically classified as "open_source" contributions
+- License-based detection identifies open source projects even with single contributors
+
 **Selection Criteria (in order of importance):**
 1. **Author Contribution Level**: Projects where the candidate has made significant contributions (high author_commit_count) - HIGHEST PRIORITY
 2. **Popular Open Source Contributions**: Contributions to well-known projects (1000+ stars) - HIGH PRIORITY
-3. **Technical Complexity**: Projects that demonstrate advanced programming concepts, architecture, or problem-solving
-4. **Real-world Impact**: Projects with actual users, deployments, or practical applications
-5. **Code Quality**: Well-documented, maintained, and professional code
-6. **Community Engagement**: Projects with stars, forks, or community contributions
-7. **Technology Stack**: Projects using modern, relevant technologies
-8. **Originality**: Unique projects rather than tutorial-based or classroom assignments
+3. **Open Source Program Participation**: Contributions with `opensource_program` detected (Hacktoberfest, GSSoC, etc.) - HIGH PRIORITY
+4. **External Pull Request Contributions**: Any merged PR to external projects - HIGHEST PRIORITY for open source engagement - HIGH PRIORITY
+5. **Technical Complexity**: Projects that demonstrate advanced programming concepts, architecture, or problem-solving
+6. **Real-world Impact**: Projects with actual users, deployments, or practical applications
+7. **Code Quality**: Well-documented, maintained, and professional code
+8. **Community Engagement**: Projects with stars, forks, or community contributions
+9. **Technology Stack**: Projects using modern, relevant technologies
+10. **Originality**: Unique projects rather than tutorial-based or classroom assignments
 
 **Projects to PRIORITIZE:**
 - Projects with high author_commit_count (15+ commits) - indicates substantial involvement and deep engagement
 - Projects with moderate author_commit_count (5-14 commits) - shows meaningful contribution
 - Contributions to popular open source projects (React, Vue, Angular, Node.js, Express, Django, Flask, TensorFlow, PyTorch, Kubernetes, Docker, VS Code, etc.)
+- Pull requests with `opensource_program` participation (Hacktoberfest, GSSoC, GSoC, etc.) 
 - Forks of popular projects with meaningful contributions
 - Projects with significant community adoption (100+ stars)
 - Projects that solve real-world problems
@@ -72,14 +85,24 @@ Prioritize contributions to popular open source projects over personal projects.
 
 [
   {
-    "name": "Project name",
-    "description": "Project description",
-    "github_url": "GitHub URL",
+    "name": "Project name (for PRs: 'owner/repo-name')",
+    "description": "Project description or PR title",
+    "github_url": "GitHub URL (PR URL for pull requests)",
     "live_url": "Live URL if available",
     "technologies": ["tech1", "tech2"],
     "reason_for_project_selection": "Reason why this project is selected",
     "author_commit_count": 0,
     "total_commit_count": 0,
+    "pr_details": {
+      "number": "PR number (only for pull requests)",
+      "title": "PR title",
+      "changed_files": "Number of files changed",
+      "commits": "Number of commits in PR"
+    },
+    "opensource_program": {
+      "program_name": "hacktoberfest/gssoc/gsoc/etc",
+      "detected": true
+    },
     "github_details": {
       "stars": 0,
       "forks": 0,

--- a/score.py
+++ b/score.py
@@ -4,7 +4,7 @@ import json
 import logging
 import csv
 from pdf import PDFHandler
-from github import fetch_and_display_github_info
+from github import fetch_github_projects_with_prs
 from models import JSONResume, EvaluationData
 from typing import List, Optional, Dict
 from evaluator import ResumeEvaluator
@@ -181,12 +181,18 @@ def main(pdf_path):
         f"cache/githubcache_{os.path.basename(pdf_path).replace('.pdf', '')}.json"
     )
 
-    # Check if cache exists and we're in development mode
+    resume_data = None
     if DEVELOPMENT_MODE and os.path.exists(cache_filename):
         print(f"Loading cached data from {cache_filename}")
-        cached_data = json.loads(Path(cache_filename).read_text())
-        resume_data = JSONResume(**cached_data)
-    else:
+        try:
+            cached_data = json.loads(Path(cache_filename).read_text(encoding='utf-8'))
+            resume_data = JSONResume(**cached_data)
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            print(f"Error loading cached resume data: {e}")
+            print("Regenerating resume data...")
+            resume_data = None
+    
+    if resume_data is None:
         logger.debug(
             f"Extracting data from PDF"
             + (" and caching to " + cache_filename if DEVELOPMENT_MODE else "")
@@ -196,14 +202,20 @@ def main(pdf_path):
         if DEVELOPMENT_MODE:
             os.makedirs(os.path.dirname(cache_filename), exist_ok=True)
             Path(cache_filename).write_text(
-                json.dumps(resume_data.model_dump(), indent=2, ensure_ascii=False)
+                json.dumps(resume_data.model_dump(), indent=2, ensure_ascii=False),
+                encoding='utf-8'
             )
 
     # Check if cache exists and we're in development mode
     github_data = {}
     if DEVELOPMENT_MODE and os.path.exists(github_cache_filename):
         print(f"Loading cached data from {github_cache_filename}")
-        github_data = json.loads(Path(github_cache_filename).read_text())
+        try:
+            github_data = json.loads(Path(github_cache_filename).read_text(encoding='utf-8'))
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            print(f"Error loading cached GitHub data: {e}")
+            print("Regenerating GitHub data...")
+            github_data = {}
     else:
         print(
             f"Fetching GitHub data"
@@ -217,11 +229,14 @@ def main(pdf_path):
         github_profile = find_profile(profiles, "Github")
 
         if github_profile:
-            github_data = fetch_and_display_github_info(github_profile.url)
+            # Fetch both owned repositories and external pull requests
+            github_projects = fetch_github_projects_with_prs(github_profile.url)
+            github_data = {"projects": github_projects}
         if DEVELOPMENT_MODE:
             os.makedirs(os.path.dirname(github_cache_filename), exist_ok=True)
             Path(github_cache_filename).write_text(
-                json.dumps(github_data, indent=2, ensure_ascii=False)
+                json.dumps(github_data, indent=2, ensure_ascii=False),
+                encoding='utf-8'
             )
 
     score = _evaluate_resume(resume_data, github_data)


### PR DESCRIPTION
## Description
Current open-source contribution is too simple

```python
project_type = "open_source" if contributor_count > 1 else "self_project"
```

This PR enhances open-source contribution detection, earlier group projects were even classified as open-source projects. Projects are considered open-source based on the license they have, not the contributor count. (Source: https://opensource.org/osd) 

We fetch all (limit=100) the PR that the user has raised and analyze based on that, we check what type of contribution has been made and to which organisation it was raised. 

## Changes

```fetch_user_pull_requests``` to fetch PRs
```determine_project_type``` to determine the project type
```fetch_github_projects_with_prs```  calling ```fetch_all_github_repos``` and ```fetch_user_pull_requests``` to get the combined result ensuring the whole data is present 

## Testing
### Gemini Provider Test:
- [x] PDF to Markdown conversion
- [x] Section extraction to JSON Resume
- [x] Evaluation with required fields

### Ollama Provider Test:
- [x] Local model functionality remains unaffected

## Notes
- Maintains provider-agnostic prompt structure as per guidelines
- Functions remain short and focused
- No model-specific tokens or formatting introduced

## Related Issue
resolves #12 
