### PR TITLE
Fix: Exclude Bot users in project classification

### DIFF
--- a/github.py
+++ b/github.py
@@ -147,6 +147,12 @@ def fetch_repo_contributors(owner: str, repo_name: str) -> int:
         api_url = f"https://api.github.com/repos/{owner}/{repo_name}/contributors"
 
         status_code, contributors_data = _fetch_github_api(api_url)
+        if status_code == 200 and isinstance(contributors_data, list):
+            contributors_data = [
+                contributor
+                for contributor in contributors_data
+                if contributor.get("type", "").lower() != "bot"
+            ]
 
         return contributors_data
 


### PR DESCRIPTION
## Description
This PR enhances the contributor counting logic for GitHub repositories. Previously, all contributors including bots were counted when determining if a project is "open_source" or "self_project". Now, only contributors with `type: "User"` are counted, ensuring more accurate classification.

## Problematic Code
Previously, the fetch_repo_contributors function in github.py counted all contributors without any filtering:

```python
status_code, contributors_data = _fetch_github_api(api_url)

return contributors_data
```

## Fix in This PR
The updated code now excludes bots:

```python
contributors_data = [
   contributor
   for contributor in contributors_data
   if contributor.get("type", "").lower() != "bot"
]
```

## Impact
- More accurate open source project classification
- Prevents inflation of contributor counts and open source repositories due to bots

## Related Issue(s)
Resolves #52 

---
