### PR TITLE
Fix #56: Remove duplicate description field from github_details

### DIFF
--- a/github.py
+++ b/github.py
@@ -208,7 +208,6 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
                         "stars": repo.get("stargazers_count", 0),
                         "forks": repo.get("forks_count", 0),
                         "language": repo.get("language"),
-                        "description": repo.get("description"),
                         "created_at": repo.get("created_at"),
                         "updated_at": repo.get("updated_at"),
                         "topics": repo.get("topics", []),


### PR DESCRIPTION
## Description
This PR fixes issue #56 by removing the redundant `description` field from the `github_details` sub-dictionary in the project object formation.

## Problem
The project dictionary was redundantly adding the `description` field at two places:
- As part of the main project dictionary
- As part of the `github_details` sub-dictionary

This created unnecessary data redundancy since the description is a general project attribute, not a GitHub-specific statistic.

## Solution
- Removed `"description": repo.get("description"),` from the `github_details` sub-dictionary
- Kept the `description` field only in the main project dictionary where it belongs
- Maintained all other GitHub-specific metrics (stars, forks, language, etc.) in `github_details`

## Changes
- Modified `github.py` in the `fetch_all_github_repos` function
- Removed 1 line of duplicate code

## Testing
- Created and ran test to verify the fix
- Confirmed `description` field appears exactly once in the project structure
- Verified `description` is present in main project dictionary but absent from `github_details`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Fixes #56