### PR TITLE
Fix: Correct GitHub profile data structure access in CSV export

### DIFF
--- a/transform.py
+++ b/transform.py
@@ -656,12 +656,13 @@ def transform_evaluation_response(
         csv_row["total_projects"] = 0
 
     # Extract GitHub data
-    if github_data:
-        csv_row["github_repos"] = github_data.get("public_repos", 0)
-        csv_row["github_followers"] = github_data.get("followers", 0)
-        csv_row["github_following"] = github_data.get("following", 0)
-        csv_row["github_created_at"] = github_data.get("created_at", "")
-        csv_row["github_bio"] = github_data.get("bio", "")
+    if github_data and "profile" in github_data:
+        profile = github_data.get("profile", {})
+        csv_row["github_repos"] = profile.get("public_repos", 0)
+        csv_row["github_followers"] = profile.get("followers", 0)
+        csv_row["github_following"] = profile.get("following", 0)
+        csv_row["github_created_at"] = profile.get("created_at", "")
+        csv_row["github_bio"] = profile.get("bio", "")
     else:
         csv_row["github_repos"] = 0
         csv_row["github_followers"] = 0


### PR DESCRIPTION
## Description
Fixes an issue where GitHub profile data was not being correctly exported to CSV. The data was being accessed from the root level of the `github_data` dictionary, but the actual data is nested under a `"profile"` key.

## Changes
- Updated `transform.py` to correctly access the nested profile data structure
- Added proper null checks to prevent potential KeyError exceptions
- Maintained backward compatibility with the existing CSV structure

## Testing
- [x] Verified with a resume containing GitHub profile
- [x] Confirmed CSV export shows correct GitHub metrics
- [x] Tested with missing/partial GitHub data

## Impact
- **Before:** All GitHub fields in CSV were 0/empty
- **After:** CSV now shows actual GitHub profile data

Closes Issue No. #61 