### PR TITLE
Fix GitHub Profile Data CSV Export Issue #61

### DIFF
--- a/transform.py
+++ b/transform.py
@@ -656,12 +656,13 @@ def transform_evaluation_response(
         csv_row["total_projects"] = 0
 
     # Extract GitHub data
-    if github_data:
-        csv_row["github_repos"] = github_data.get("public_repos", 0)
-        csv_row["github_followers"] = github_data.get("followers", 0)
-        csv_row["github_following"] = github_data.get("following", 0)
-        csv_row["github_created_at"] = github_data.get("created_at", "")
-        csv_row["github_bio"] = github_data.get("bio", "")
+    if github_data and "profile" in github_data:
+        profile = github_data["profile"]
+        csv_row["github_repos"] = profile.get("public_repos", 0)
+        csv_row["github_followers"] = profile.get("followers", 0)
+        csv_row["github_following"] = profile.get("following", 0)
+        csv_row["github_created_at"] = profile.get("created_at", "")
+        csv_row["github_bio"] = profile.get("bio", "")
     else:
         csv_row["github_repos"] = 0
         csv_row["github_followers"] = 0


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes issue where GitHub profile data fields (repos count, followers, following, etc.) were being exported as zeros or empty strings in CSV files, even when the GitHub profile data was successfully fetched.

## 🔍 Root Cause

The issue was in the `transform_evaluation_response` function in `transform.py`. The code was trying to access GitHub profile fields directly from the root level of `github_data`, but the actual data structure returned by `fetch_and_display_github_info` has the profile data nested under a "profile" key.

**Before (Broken):**
```python
csv_row["github_repos"] = github_data.get("public_repos", 0)
```

**After (Fixed):**
```python
if github_data and "profile" in github_data:
    profile = github_data["profile"]
    csv_row["github_repos"] = profile.get("public_repos", 0)
```

## ✅ Changes Made

- Updated GitHub data extraction logic in `transform.py` (lines 658-671)
- Added proper check for `github_data` and `"profile"` key existence
- Now correctly accesses nested profile data from `github_data["profile"]`
- Maintains backward compatibility with proper fallback values

## 🧪 Testing

**Tested with:**
- ✅ Sample data with known values
- ✅ Real GitHub API data (octocat profile)
- ✅ Edge cases (no data, empty data, missing profile key)
- ✅ All GitHub profile fields now export correctly:
  - `github_repos`: Number of public repositories
  - `github_followers`: Number of followers
  - `github_following`: Number of users followed
  - `github_created_at`: Account creation date
  - `github_bio`: User's GitHub bio

## 📊 Results

**Before:** All GitHub fields exported as 0 or empty strings
**After:** All GitHub fields export with actual values from GitHub API

## 🔗 Related

- Closes #61
- Resolves GitHub profile data CSV export issue