### PR TITLE
feat: add certificate and volunteer experience extraction with PDFHandler integration

### DIFF
--- a/prompts/templates/certificates.jinja
+++ b/prompts/templates/certificates.jinja
@@ -1,0 +1,23 @@
+{% raw %}
+## Certificates Extraction
+
+Extract the certificate section from the resume.
+
+Instructions:
+- List all certificates, online courses, training programs, and relevant credentials.
+- For each certificate, include:
+  - Certificate name
+  - Issuing organization
+  - Date obtained (if mentioned)
+  - Description or relevance (if present)
+- Output as a JSON array of objects:
+  [
+    {
+      "name": "Certificate Name",
+      "issuer": "Issuing Organization",
+      "date": "YYYY-MM-DD or Month Year",
+      "description": "Brief description or relevance"
+    },
+    ...
+  ]
+{% endraw %}

--- a/prompts/templates/volunteer_experience.jinja
+++ b/prompts/templates/volunteer_experience.jinja
@@ -1,0 +1,23 @@
+{% raw %}
+## Volunteer Experience Extraction
+
+Extract the volunteer experience section from the resume.
+
+Instructions:
+- List all volunteer work, community service, NGO involvement, and unpaid initiatives.
+- For each experience, include:
+  - Organization name
+  - Role or position
+  - Duration or date range
+  - Description of impact or responsibilities
+- Output as a JSON array of objects:
+  [
+    {
+      "organization": "Organization Name",
+      "role": "Volunteer Position",
+      "duration": "Start-End or Duration",
+      "description": "Summary of impact or activities"
+    },
+    ...
+  ]
+{% endraw %}


### PR DESCRIPTION
Fixes #65

This pull request adds support for extracting certificate and volunteer experience sections from resumes in the hiring-agent pipeline.

- Added Jinja templates for certificates and volunteer_experience in prompts/templates/
- Integrated extraction logic into PDFHandler in pdf.py
- Updated section extraction and pipeline orchestration
- Validated testing on Ollama gemma3:1b model

This improves the candidate evaluation coverage by including these important resume sections.