### PR TITLE
fix: exclude bot accounts from contributor classification

### DIFF
--- a/github.py
+++ b/github.py
@@ -182,10 +182,17 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
                 repo_name = repo.get("name")
 
                 contributors_data = fetch_repo_contributors(username, repo_name)
-                contributor_count = len(contributors_data)
+
+                real_contributors = [
+                    c for c in contributors_data
+                    if not c.get("type", "").lower() == "bot"
+                       and not c.get("login", "").endswith("[bot]")
+                ]
+
+                contributor_count = len(real_contributors)
 
                 user_contributions, total_contributions = fetch_contributions_count(
-                    username, contributors_data
+                    username, real_contributors
                 )
 
                 project_type = (


### PR DESCRIPTION
## Description

This PR updates the repository classification logic to exclude bot accounts (e.g., Dependabot, GitHub Actions) from the contributor count. Previously, bot contributors were included, which could incorrectly classify some repositories as open_source instead of self_project.

## Changes Made

- Updated fetch_repo_contributors logic to filter out bot accounts.

- Contributor counts now only include real human contributors.

## Testing Results
For the repo [OldPortfolio](https://github.com/awesohame/OldPortfolio)

**Before:**  
![before](https://github.com/user-attachments/assets/77a44d91-b6c1-4ab2-b5d5-045907707857)

**After:**  
![after](https://github.com/user-attachments/assets/235d6764-ac21-44e4-8164-f69f2cb1bdc1)

---

**Linked Issue**

Closes #52 