### PR TITLE
Fix: Add robust error handling for JSON parsing in extract_json_from_response

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -79,7 +79,12 @@ class ResumeEvaluator:
 
             response_text = response["message"]["content"]
             response_text = extract_json_from_response(response_text)
-            logger.error(f"🔤 Prompt response: {response_text}")
+            
+            if response_text is None:
+                logger.error("❌ Failed to extract valid JSON from LLM response")
+                raise ValueError("Invalid JSON response from LLM")
+                
+            logger.debug(f"🔤 Prompt response: {response_text}")
 
             evaluation_dict = json.loads(response_text)
             evaluation_data = EvaluationData(**evaluation_dict)

--- a/github.py
+++ b/github.py
@@ -237,11 +237,11 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
             )
             return projects
 
-        elif response.status_code == 404:
+        elif status_code == 404:
             print(f"GitHub user not found: {username}")
             return []
         else:
-            print(f"GitHub API error: {response.status_code} - {response.text}")
+            print(f"GitHub API error: {status_code} - {data}")
             return []
 
     except requests.exceptions.RequestException as e:
@@ -341,6 +341,11 @@ def generate_projects_json(projects: List[Dict]) -> List[Dict]:
         try:
             response_text = response_text.strip()
             response_text = extract_json_from_response(response_text)
+            
+            if response_text is None:
+                print("❌ Failed to extract valid JSON from LLM response")
+                print("🔄 Falling back to first 7 projects")
+                return projects_data[:7]
 
             selected_projects = json.loads(response_text)
 

--- a/pdf.py
+++ b/pdf.py
@@ -110,6 +110,10 @@ class PDFHandler:
 
             try:
                 response_text = extract_json_from_response(response_text)
+                if response_text is None:
+                    logger.error(f"❌ Failed to extract valid JSON for {section_name} section")
+                    return None
+                    
                 json_start = response_text.find("{")
                 json_end = response_text.rfind("}")
                 if json_start != -1 and json_end != -1:


### PR DESCRIPTION
## 🐛 Fix: Add robust error handling for JSON parsing in `extract_json_from_response`

This PR addresses the issue of the application crashing when the LLM returns malformed JSON responses.

### Key Changes:

**`llm_utils.py`:**
- Implemented `try-except` blocks around JSON parsing within `extract_json_from_response`
- The function now returns `None` if JSON parsing fails, preventing `json.JSONDecodeError`
- Added comprehensive error logging for debugging malformed responses

**Calling Functions (`pdf.py`, `github.py`, `evaluator.py`):**
- Updated to gracefully handle `None` return values from `extract_json_from_response`
- **`pdf.py`**: Returns `None` for section extraction on parsing failure
- **`github.py`**: Falls back to the first 7 projects if project selection JSON is malformed
- **`evaluator.py`**: Raises a `ValueError` for invalid LLM JSON responses

**`github.py`:**
- Fixed an undefined `response` variable bug in error handling (lines 240-244)

### Impact:
- ✅ Enhances application stability by preventing crashes due to invalid LLM output
- ✅ Improves user experience with graceful degradation and fallback mechanisms
- ✅ Facilitates debugging with detailed error logs

### Testing:
- [x] Tested with valid JSON responses
- [x] Tested with malformed JSON responses
- [x] Tested with markdown-wrapped JSON
- [x] Tested with `<think>` tags
- [x] Verified error logging works correctly

**Resolves #68**