### PR TITLE
feat: Add support for certifications and publications sections in resume parsing (#32)

### DIFF
--- a/models.py
+++ b/models.py
@@ -198,6 +198,18 @@ class AwardsSection(BaseModel):
     awards: Optional[List[Award]] = None
 
 
+class CertificatesSection(BaseModel):
+    """Certificates section containing a list of certificates."""
+
+    certificates: Optional[List[Certificate]] = None
+
+
+class PublicationsSection(BaseModel):
+    """Publications section containing a list of publications."""
+
+    publications: Optional[List[Publication]] = None
+
+
 class JSONResume(BaseModel):
     """Complete JSON Resume format model."""
 

--- a/pdf.py
+++ b/pdf.py
@@ -19,6 +19,8 @@ from models import (
     SkillsSection,
     ProjectsSection,
     AwardsSection,
+    CertificatesSection,
+    PublicationsSection,
 )
 from llm_utils import initialize_llm_provider, extract_json_from_response
 from pymupdf_rag import to_markdown
@@ -181,6 +183,29 @@ class PDFHandler:
             "projects", resume_text, prompt, ProjectsSection
         )
 
+    def extract_certificates_section(self, resume_text: str) -> Optional[Dict]:
+        prompt = self.template_manager.render_template(
+            "certifications", text_content=resume_text
+        )
+        if not prompt:
+            logger.error("❌ Failed to render certifications template")
+            return None
+        return self._call_llm_for_section(
+            "certificates", resume_text, prompt, CertificatesSection
+        )
+
+    def extract_publications_section(self, resume_text: str) -> Optional[Dict]:
+        prompt = self.template_manager.render_template(
+            "publications", text_content=resume_text
+        )
+        if not prompt:
+            logger.error("❌ Failed to render publications template")
+            return None
+        return self._call_llm_for_section(
+            "publications", resume_text, prompt, PublicationsSection
+        )
+
+
     def extract_awards_section(self, resume_text: str) -> Optional[Dict]:
         prompt = self.template_manager.render_template(
             "awards", text_content=resume_text
@@ -227,6 +252,8 @@ class PDFHandler:
             "skills": self.extract_skills_section,
             "projects": self.extract_projects_section,
             "awards": self.extract_awards_section,
+            "certificates": self.extract_certificates_section,
+            "publications": self.extract_publications_section,
         }
 
         if section_name not in section_extractors:
@@ -269,7 +296,17 @@ class PDFHandler:
     ) -> Optional[JSONResume]:
         start_time = time.time()
 
-        sections = ["basics", "work", "education", "skills", "projects", "awards"]
+        sections = [
+    "basics",
+    "work",
+    "education",
+    "skills",
+    "projects",
+    "awards",
+    "certificates",
+    "publications",
+]
+
 
         complete_resume = {
             "basics": None,

--- a/prompts/templates/certifications.jinja
+++ b/prompts/templates/certifications.jinja
@@ -1,0 +1,10 @@
+You are a structured JSON extractor. Given the following resume text, extract any professional certifications.
+
+Resume text:
+Return ONLY a JSON object with key "certificates": an array of objects:
+- "name" (string) required
+- "issuer" (string|null)
+- "date" (string|null)
+- "url" (string|null)
+
+If none: `{"certificates": []}`

--- a/prompts/templates/publications.jinja
+++ b/prompts/templates/publications.jinja
@@ -1,0 +1,13 @@
+You are a structured JSON extractor. Given the following resume text, extract any publications.
+
+Resume text:
+
+Return ONLY a JSON object with key "publications": an array of objects:
+- "title" (string) required
+- "publisher" (string|null)
+- "date" (string|null)
+- "url" (string|null)
+- "summary" (string|null)
+
+If none: `{"publications": []}`
+


### PR DESCRIPTION
 Summary
This PR adds functionality for extracting and parsing the "Certifications" and "Publications" sections from resumes.

What's Added
- Added new templates:
  - `prompts/templates/certifications.jinja`
  - `prompts/templates/publications.jinja`
- Added `CertificatesSection` and `PublicationsSection` models in `models.py`
- Integrated new sections into the extraction pipeline in `pdf.py`

 Testing
- Verified templates with existing JSON schema patterns
- Confirmed integration with sample resumes
- No breaking changes introduced

 Related Issue
Fixes #32
