### PR TITLE
Fix & Feat: Added GROQ and fixed bug #77 and #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ cp .env.example .env
 
 | Variable         | Values                                      | Description                                                            |
 | ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
+| `LLM_PROVIDER`   | `ollama` or `gemini` or `groq`              | Chooses provider. Defaults to Ollama.                                  |
 | `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
 | `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
 | `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
-
+| `GROQ_API_KEY`   | string                                      | Required when `LLM_PROVIDER=groq`.                                   |
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
 
 ```python
@@ -260,6 +260,11 @@ What happens:
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
 
+## Groq
+- Set `LLM_PROVIDER=groq`
+- Set `DEFAULT_MODEL` to a supported Groq model, for example `openai/gpt-oss-120b`
+- Provide `GROQ_API_KEY`
+- The wrapper in `models.GroqProvider` adapts responses to a unified format
 ---
 
 ## Contributing

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,8 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import ModelProvider, OllamaProvider, GeminiProvider, GroqProvider
+from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY, PROVIDER, GROQ_API_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -50,13 +50,22 @@ def initialize_llm_provider(model_name: str) -> Any:
     # Default to Ollama provider
     provider = OllamaProvider()
     # If using Gemini and API key is available, use Gemini provider
-    model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
+    model_provider_name = PROVIDER
+    model_provider = MODEL_PROVIDER_MAPPING.get(
+        model_provider_name, ModelProvider.OLLAMA
+    )
     if model_provider == ModelProvider.GEMINI:
         if not GEMINI_API_KEY:
             logger.warning("⚠️ Gemini API key not found. Falling back to Ollama.")
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.GROQ:
+        if not GROQ_API_KEY:
+            logger.warning("⚠️ Groq API key not found. Falling back to Ollama.")
+        else:
+            logger.info(f"🔄 Using Groq API provider with model {model_name}")
+            provider = GroqProvider(api_key=GROQ_API_KEY)
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
     return provider

--- a/prompt.py
+++ b/prompt.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 from models import ModelProvider
 
 # Load environment variables
-load_dotenv(override=True)
+load_dotenv()
 
 # Constants
 DEFAULT_MODEL_NAME = "gemma3:4b"

--- a/prompt.py
+++ b/prompt.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 from models import ModelProvider
 
 # Load environment variables
-load_dotenv()
+load_dotenv(override=True)
 
 # Constants
 DEFAULT_MODEL_NAME = "gemma3:4b"
@@ -39,25 +39,23 @@ MODEL_PARAMETERS = {
     "gemini-2.5-pro": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # Groq Models
+    "openai/gpt-oss-20b": {"temperature": 0.1, "top_p": 0.9},
+    "openai/gpt-oss-120b": {"temperature": 0.1, "top_p": 0.9},
+    "llama-3.3-70b-versatile": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
 # Maps model names to their provider
 MODEL_PROVIDER_MAPPING = {
     # Ollama models
-    "qwen3:1.7b": ModelProvider.OLLAMA,
-    "gemma3:1b": ModelProvider.OLLAMA,
-    "qwen3:4b": ModelProvider.OLLAMA,
-    "gemma3:4b": ModelProvider.OLLAMA,
-    "gemma3:12b": ModelProvider.OLLAMA,
-    "mistral:7b": ModelProvider.OLLAMA,
+    "ollama": ModelProvider.OLLAMA,
     # Google Gemini models
-    "gemini-2.0-flash": ModelProvider.GEMINI,
-    "gemini-2.0-flash-lite": ModelProvider.GEMINI,
-    "gemini-2.5-flash": ModelProvider.GEMINI,
-    "gemini-2.5-flash-lite": ModelProvider.GEMINI,
-    "gemini-2.5-pro": ModelProvider.GEMINI,
+    "gemini": ModelProvider.GEMINI,
+    # Groq models
+    "groq": ModelProvider.GROQ,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")


### PR DESCRIPTION
This PR adds GROQ provider support as an alternative LLM backend and fixes a bug where the LLM_PROVIDER environment variable was not respected during initialization.

Key Changes

Feature: Implemented GroqProvider using the official SDK.
Enhancement: Added rate limit handling for GROQ and Gemini.
Fix: Corrected provider selection to use the LLM_PROVIDER environment variable instead of inferring from model name.

Configuration

To enable GROQ, set:

LLM_PROVIDER=groq
GROQ_API_KEY="YOUR_API_KEY"
DEFAULT_MODEL=openai/gpt-oss-120b


Benefits

Expands flexibility with GROQ as a fallback when Gemini’s free-tier rate limits are restrictive.
Ensures environment variable configuration is honored consistently.
Maintains a consistent provider structure across Ollama, Gemini, and GROQ.

Checklist

 [-]Added GroqProvider implementation
 [-]Added proper rate limit handling for GROQ and Gemini
 [-]Fixed LLM_PROVIDER bug
 []Update documentation with new provider setup
 
 Isuue #77 and #78 