### PR TITLE
fix: NameError in fetch_all_github_repos function

### DIFF
--- a/github.py
+++ b/github.py
@@ -237,11 +237,12 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
             )
             return projects
 
-        elif response.status_code == 404:
+        elif status_code == 404:
             print(f"GitHub user not found: {username}")
             return []
         else:
-            print(f"GitHub API error: {response.status_code} - {response.text}")
+            error_msg = repos_data.get("message", "Unknown error") if isinstance(repos_data, dict) else str(repos_data)            
+            print(f"GitHub API error: {status_code} - {error_msg}")
             return []
 
     except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Fixes Issue #86 

This PR resolves a NameError in the `fetch_all_github_repos` function where undefined `response` variable was being referenced.