### PR TITLE
fix: achievements were not picked up as awards

### DIFF
--- a/prompts/templates/awards.jinja
+++ b/prompts/templates/awards.jinja
@@ -1,4 +1,4 @@
-Extract ONLY the awards and honors information from this resume.
+Extract ONLY the awards and honors (including achievements) information from this resume.
 
 --- The input markdown starts here ---
 


### PR DESCRIPTION
Before: Resume's cached JSON did not pick up any awards 
After: Resume's cached JSON picks up awards (labelled as achievements in resume)

This closes #95 