### PR TITLE
Fix undefined variable reference in GitHub API error handling

### DIFF
--- a/github.py
+++ b/github.py
@@ -237,11 +237,11 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
             )
             return projects
 
-        elif response.status_code == 404:
+        elif status_code == 404:
             print(f"GitHub user not found: {username}")
             return []
         else:
-            print(f"GitHub API error: {response.status_code} - {response.text}")
+            print(f"GitHub API error: {status_code} - {repos_data}")
             return []
 
     except requests.exceptions.RequestException as e:


### PR DESCRIPTION
## Description

Fixes a critical bug where undefined variables were referenced in the GitHub API error handling code, causing `NameError` exceptions when API calls fail.

## Problem

The `fetch_all_github_repos` function in `github.py` was referencing undefined variables `response.status_code` and `response.text` in error handling blocks, even though the function uses `_fetch_github_api()` which returns `(status_code, data)` instead of a response object.

## Solution

Replaced the undefined variable references with the correct variables:
- `response.status_code` → `status_code`
- `response.text` → `repos_data`

## Changes Made

- **File**: `github.py`
- **Lines**: 240, 244
- **Function**: `fetch_all_github_repos`

```diff
- elif response.status_code == 404:
+ elif status_code == 404:
    print(f"GitHub user not found: {username}")
    return []
  else:
-   print(f"GitHub API error: {response.status_code} - {response.text}")
+   print(f"GitHub API error: {status_code} - {repos_data}")
    return []
```

## Testing

✅ Tested with non-existent GitHub user (404 error path)  
✅ Tested with invalid URL format (error path)  
✅ No `NameError` exceptions occur  
✅ Error handling works as expected  

## Impact

- **Before**: Application crashes with `NameError` when GitHub API calls fail
- **After**: Graceful error handling with proper error messages
- **Severity**: Critical bug fix

## Related Issues

Fixes #106

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update