### PR TITLE
Fix : Use UTF-8 encoding when caching Github data to prevent charmap errors

### DIFF
--- a/github.py
+++ b/github.py
@@ -47,7 +47,8 @@ def _fetch_github_api(api_url, params=None):
         try:
             os.makedirs("cache", exist_ok=True)
             Path(cache_filename).write_text(
-                json.dumps(data, indent=2, ensure_ascii=False)
+                json.dumps(data, indent=2, ensure_ascii=False),
+                encoding="utf-8"
             )
             print(f"Cached GitHub data to {cache_filename}")
         except Exception as e:


### PR DESCRIPTION
This PR fixes an issue where caching Github API responses on Windows fails with the error :
`'charmap' codec can't encode characters in position XXXX-XXXX: character maps to <undefined>`

Closes Issue #116 

Changes Made : 
1. Added `encoding="utf-8"` when writting JSON cache files in _fetch_github_api.
2. Preserves all Unicode characters in cached data.