### PR TITLE
fix : fixed an unreachable code error in fetch_repo_contributors func…

### DIFF
--- a/github.py
+++ b/github.py
@@ -142,22 +142,20 @@ def fetch_contributions_count(owner: str, contributors_data):
     return user_contributions, total_contributions
 
 
-def fetch_repo_contributors(owner: str, repo_name: str) -> int:
+def fetch_repo_contributors(owner: str, repo_name: str) -> list[dict]:
     try:
         api_url = f"https://api.github.com/repos/{owner}/{repo_name}/contributors"
 
         status_code, contributors_data = _fetch_github_api(api_url)
 
-        return contributors_data
-
         if status_code == 200:
-            return len(contributors_data)
+            return contributors_data
         else:
-            return 1
+            return []
 
     except Exception as e:
         logger.error(f"Error fetching contributors for {owner}/{repo_name}: {e}")
-        return 1
+        return []
 
 
 def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:


### PR DESCRIPTION
# Fix `fetch_repo_contributors` to Return Full Contributor List (#119 )

## Description
This PR addresses issue [#119] by fixing the `fetch_repo_contributors` function.

### Changes made
- The function now returns the **full list of contributors** instead of just a count, allowing downstream code to filter bots correctly.  
- Updated the function signature to `-> list[dict]` to reflect the actual return type.  
- Returns an **empty list** `[]` for non-200 responses or exceptions instead of `1`, making it safer for downstream processing.

## Code Reference
```python
def fetch_repo_contributors(owner: str, repo_name: str) -> list[dict]:
    try:
        api_url = f"https://api.github.com/repos/{owner}/{repo_name}/contributors"
        status_code, contributors_data = _fetch_github_api(api_url)

        if status_code == 200:
            return contributors_data
        else:
            return []

    except Exception as e:
        logger.error(f"Error fetching contributors for {owner}/{repo_name}: {e}")
        return []
```
### Issue
Closes [#119]