### PR TITLE
 fix(pymupdf_rag): include index 0 when iterating img_info

### DIFF
--- a/pymupdf_rag.py
+++ b/pymupdf_rag.py
@@ -1162,7 +1162,8 @@ def to_markdown(
 
         img_info = img_info[:30]  # only accept the largest up to 30 images
         # run from back to front (= small to large)
-        for i in range(len(img_info) - 1, 0, -1):
+        # include index 0 in the reverse iteration (stop should be -1)
+        for i in range(len(img_info) - 1, -1, -1):
             r = img_info[i]["bbox"]
             if r.is_empty:
                 del img_info[i]


### PR DESCRIPTION
Fix off-by-one bug in pymupdf_rag.to_markdown image filtering loop.

Problem:
The reverse iteration used `range(len(img_info) - 1, 0, -1)` which skipped
index 0 and could leave behind images that should have been checked for
containment or emptiness. This could cause small images to be incorrectly
included in output.

Fix:
Use `range(len(img_info) - 1, -1, -1)` so the reverse loop includes index 0.

Notes:
- This is a small, focused, low-risk fix.
- Ruff reports many style issues in `pymupdf_rag.py` unrelated to this change;
  I intentionally limited the change to this single bugfix.
- I can follow up with additional style cleanup/formatting PRs if desired.

