### PR TITLE
fix: specify UTF-8 encoding when writing cache files to prevent Unico…

### DIFF
--- a/github.py
+++ b/github.py
@@ -47,7 +47,8 @@ def _fetch_github_api(api_url, params=None):
         try:
             os.makedirs("cache", exist_ok=True)
             Path(cache_filename).write_text(
-                json.dumps(data, indent=2, ensure_ascii=False)
+                json.dumps(data, indent=2, ensure_ascii=False),
+                encoding='utf-8'
             )
             print(f"Cached GitHub data to {cache_filename}")
         except Exception as e:

--- a/score.py
+++ b/score.py
@@ -225,7 +225,8 @@ def main(pdf_path):
         if DEVELOPMENT_MODE:
             os.makedirs(os.path.dirname(cache_filename), exist_ok=True)
             Path(cache_filename).write_text(
-                json.dumps(resume_data.model_dump(), indent=2, ensure_ascii=False)
+                json.dumps(resume_data.model_dump(), indent=2, ensure_ascii=False),
+                encoding='utf-8'
             )
 
     # Check if cache exists and we're in development mode
@@ -250,7 +251,8 @@ def main(pdf_path):
         if DEVELOPMENT_MODE:
             os.makedirs(os.path.dirname(github_cache_filename), exist_ok=True)
             Path(github_cache_filename).write_text(
-                json.dumps(github_data, indent=2, ensure_ascii=False)
+                json.dumps(github_data, indent=2, ensure_ascii=False),
+                encoding='utf-8'
             )
 
     score = _evaluate_resume(resume_data, github_data)


### PR DESCRIPTION
## Description
Fixes #128 

This PR adds explicit UTF-8 encoding when writing cache files to prevent `UnicodeEncodeError` on Windows systems.

## Problem
On Windows, `Path.write_text()` defaults to the system encoding (cp1252), which cannot handle Unicode characters like emojis, accented letters, etc. This causes crashes when caching GitHub data or resume information containing such characters.

## Solution
Added `encoding='utf-8'` parameter to all `Path.write_text()` calls that write JSON cache files:
- `github.py` line 49 (GitHub API cache)
- `score.py` line 227 (Resume data cache)
- `score.py` line 252 (GitHub profile cache)

## Testing
- ✅ Tested locally on Windows 11
- ✅ Confirmed cache files write successfully with Unicode characters
- ✅ No functional changes, only encoding parameter added

## Impact
- Ensures cross-platform compatibility
- Prevents crashes on Windows when processing resumes/profiles with Unicode content
- No breaking changes