### PR TITLE
fix: use context manager for PyMuPDF document to prevent memory leaks

### DIFF
--- a/pdf.py
+++ b/pdf.py
@@ -50,16 +50,16 @@ class PDFHandler:
             if not os.path.exists(pdf_path):
                 raise FileNotFoundError(f"PDF file not found: {pdf_path}")
 
-            doc = pymupdf.open(pdf_path)
-            pages = range(doc.page_count)
-            resume_text = to_markdown(
-                doc,
-                pages=pages,
-            )
-            logger.debug(
-                f"Extracted text from PDF: {len(resume_text) if resume_text else 0} characters"
-            )
-            return resume_text
+            with pymupdf.open(pdf_path) as doc:
+                pages = range(doc.page_count)
+                resume_text = to_markdown(
+                    doc,
+                    pages=pages,
+                )
+                logger.debug(
+                    f"Extracted text from PDF: {len(resume_text) if resume_text else 0} characters"
+                )
+                return resume_text
         except Exception as e:
             logger.error(f"An error occurred while reading the PDF: {e}")
             return None


### PR DESCRIPTION
Fixes memory leak when processing multiple PDF resumes

## Problem

I noticed memory usage was growing continuously when processing batches of resumes. After going through about 50 PDFs, the script was using several hundred MB more than when it started.

Tracked it down to `pdf.py` line 53 - the PyMuPDF document object wasn't being closed after extraction. PyMuPDF docs mention that documents need to be explicitly closed or you get memory leaks.

## Changes

- Changed `pymupdf.open()` to use `with` statement (context manager)
- This automatically closes the document after use, even if there's an error
- Same pattern that's already used in `pymupdf_rag.py` for consistency

## Testing

✅ Tested with 50+ PDFs - memory stays stable now
✅ Single PDF processing - works same as before  
✅ Error cases - document still closes properly

## Details

**File changed:** `pdf.py`  
**Method:** `extract_text_from_pdf()`

Before:
```python
doc = pymupdf.open(pdf_path)
pages = range(doc.page_count)
resume_text = to_markdown(doc, pages=pages)
return resume_text  # doc never gets closed
```

After:
```python
with pymupdf.open(pdf_path) as doc:  # closes automatically
    pages = range(doc.page_count)
    resume_text = to_markdown(doc, pages=pages)
    return resume_text
```

Fixes #132 
