### PR TITLE
Fix: Inconsistencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@
   - [Ollama models](#ollama-models)
 - [Configuration](#configuration)
 - [How it works](#how-it-works)
+- [CLI usage](#cli-usage)
 - [Directory layout](#directory-layout)
+- [Provider details](#provider-details)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -122,6 +124,8 @@ $ ollama pull gemma3:12b
 $ ollama pull gemma3:1b
 ```
 
+---
+
 ## Configuration
 
 Copy the template and set your environment variables.
@@ -211,6 +215,8 @@ What happens:
 2. If a GitHub profile is found in the resume, repositories are fetched and cached to `cache/githubcache_<basename>.json`.
 3. The evaluator prints a report and, in development mode, appends a CSV row to `resume_evaluations.csv`.
 
+---
+
 ## Directory layout
 
 ```text
@@ -264,13 +270,14 @@ What happens:
 
 ## Contributing
 
+Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed guidelines on filing issues, proposing changes, and submitting pull requests. Key principles include:
+
 - Keep prompts declarative and provider-agnostic.
 - Validate changes with a couple of real resumes under different providers.
 - Add or adjust unit-free smoke tests that call each stage with minimal inputs.
 
-## Contributing
+---
 
-Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on filing issues, proposing changes, and submitting pull requests.
 
 ## License
 


### PR DESCRIPTION
This PR addresses several formatting inconsistencies and errors in the `README.md` file to improve its overall clarity, readability, and navigation.

#### Closes #141  
### Changes Made

- [x] **Merged Duplicate Sections:** Combined the two `## Contributing` sections into a single, clear section to remove redundancy.
- [x] **Completed Table of Contents:** Added the missing links for `CLI usage` and `Provider details` to the `Contents` section so it accurately reflects the document structure.
- [x] **Standardized Separators:** Added horizontal rules (`---`) between all top-level sections for a consistent and clean visual layout.

### For Future Consideration (Discussion)

I noticed that the `Installation and Setup` section in the Table of Contents has indented sub-sections for its headings (like `Prerequisites`, `Quick setup`, etc.), which is very helpful for navigation.

The `CLI usage` and `Provider details` sections could also benefit from this structure. But I chose **not** to include this change in this initial PR because I saw that other sections (like `How it works`) also don't have this detailed breakdown. I wanted to get your review first on whether you'd prefer this more detailed structure to be applied consistently.

If you think it's a good idea, I'm happy to create a follow-up PR to implement it.

Looking forward to your feedback!