### PR TITLE
Add pre-commit black hook for consistent code formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.9.0  # check https://github.com/psf/black/tags for the latest version
+    hooks:
+      - id: black
+        language_version: python3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,21 @@ Thanks for your interest in improving this project. Contributions are welcome, i
 * Use [Black](https://black.readthedocs.io/en/stable/) for formatting.
 * Keep functions short and focused. Prefer pure helpers for prompt assembly and transformations.
 
+### Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com/) hooks to maintain code quality. The following hooks are configured:
+
+- **black**: Python code formatter to ensure consistent code style.
+
+**Setup:**
+
+1. Install pre-commit hooks: `pre-commit install`
+
+The hooks will run automatically on every commit. To manually run all hooks on all files, use:
+```bash
+pre-commit run --all-files
+```
+
 ### Prompts and Providers
 
 * Keep prompts declarative and provider agnostic.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Jinja2==3.1.6
 google-generativeai==0.4.0
 python-dotenv==1.0.1
 black==25.9.0
+pre_commit==4.3.0


### PR DESCRIPTION
## Add pre-commit hook for consistent code formatting

I noticed contributors were not using formatting consistently, so I've added a pre-commit hook with Black to automatically enforce our formatting standards.

This will help maintain code consistency and catch formatting issues before they're committed.

**What's included:**
- `.pre-commit-config.yaml` with Black formatter
- Updated README with setup instructions

**To use:** Run `pre-commit install`