### PR TITLE
feat: litellm integrated for multiple llm providers

### DIFF
--- a/pdf.py
+++ b/pdf.py
@@ -39,11 +39,11 @@ class PDFHandler:
 
     def __init__(self):
         self.template_manager = TemplateManager()
-        self._initialize_llm_provider()
+        self._initialize_llm_provider(use_litellm=True)
 
-    def _initialize_llm_provider(self):
+    def _initialize_llm_provider(self, use_litellm=False):
         """Initialize the appropriate LLM provider based on the model."""
-        self.provider = initialize_llm_provider(DEFAULT_MODEL)
+        self.provider = initialize_llm_provider(DEFAULT_MODEL, use_litellm)
 
     def extract_text_from_pdf(self, pdf_path: str) -> Optional[str]:
         try:

--- a/prompt.py
+++ b/prompt.py
@@ -39,6 +39,17 @@ MODEL_PARAMETERS = {
     "gemini-2.5-pro": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # DeepSeek models
+    "deepseek/deepseek-chat": {"temperature": 0.1, "top_p": 0.9},
+    "deepseek/deepseek-coder": {"temperature": 0.1, "top_p": 0.9},
+    # OpenAI models
+    "openai/gpt-4": {"temperature": 0.1, "top_p": 0.9},
+    "openai/gpt-4-turbo": {"temperature": 0.1, "top_p": 0.9},
+    "openai/gpt-3.5-turbo": {"temperature": 0.1, "top_p": 0.9},
+    # Anthropic models
+    "anthropic/claude-3-opus-20240229": {"temperature": 0.1, "top_p": 0.9},
+    "anthropic/claude-3-sonnet-20240229": {"temperature": 0.1, "top_p": 0.9},
+    "anthropic/claude-3-haiku-20240307": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -57,7 +68,24 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-flash": ModelProvider.GEMINI,
     "gemini-2.5-flash-lite": ModelProvider.GEMINI,
     "gemini-2.5-pro": ModelProvider.GEMINI,
+    # DeepSeek models
+    "deepseek/deepseek-chat": ModelProvider.DEEPSEEK,
+    "deepseek/deepseek-coder": ModelProvider.DEEPSEEK,
+    # OpenAI models
+    "openai/gpt-4": ModelProvider.OPENAI,
+    "openai/gpt-4-turbo": ModelProvider.OPENAI,
+    "openai/gpt-3.5-turbo": ModelProvider.OPENAI,
+    # Anthropic models
+    "anthropic/claude-3-opus-20240229": ModelProvider.ANTHROPIC,
+    "anthropic/claude-3-sonnet-20240229": ModelProvider.ANTHROPIC,
+    "anthropic/claude-3-haiku-20240307": ModelProvider.ANTHROPIC,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY", "")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+
+# Ollama API base URL
+OLLAMA_API_BASE = os.getenv("OLLAMA_API_BASE", "http://localhost:11434")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Jinja2==3.1.6
 google-generativeai==0.4.0
 python-dotenv==1.0.1
 black==25.9.0
+litellm==1.78.2


### PR DESCRIPTION
Closes #156 

# Summary
Replaced custom provider implementations with LiteLLM to enable unified access to multiple LLM providers (Ollama, Gemini, DeepSeek, OpenAI, Anthropic) through a single, consistent interface.

# Changes made

1. Added LiteLLM Provider (models.py)
- Created LiteLLMProvider class with unified completion API
- Supports streaming, JSON format, temperature, and top_p parameters
- Automatic response format conversion for compatibility
- Configurable api_base for local providers (Ollama)

2. Updated LLM Initialization (llm_utils.py)
- Modified initialize_llm_provider() to use LiteLLM by default
- Automatic Ollama model prefixing (ollama/{model_name})
- Maintains backward compatibility with legacy providers (use_litellm=False)
- Smart provider detection based on model name

3. Enhanced Provider Support [models.py]
- Extended ModelProvider enum with:
    - `DEEPSEEK`
    - `OPENAI`
    - `ANTHROPIC`

4. Configuration Updates (prompt.py)
- Added model parameters for DeepSeek, OpenAI, and Anthropic models
- Added provider mappings for new models
- Added environment variable support:
    - `DEEPSEEK_API_KEY`
    - `OPENAI_API_KEY`
    - `ANTHROPIC_API_KEY`
    - `OLLAMA_API_BASE` (default: `http://localhost:11434`)