### PR TITLE
Correctly fetch and display parent repo stats for forks

### DIFF
--- a/github.py
+++ b/github.py
@@ -283,11 +283,6 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
             print(
                 f"📊 Project classification: {open_source_count} open source, {self_project_count} self projects"
             )
-            
-            print("Open Source Repos => ")
-            for project in projects:
-                if(project["project_type"] == "open_source"):
-                    print(project["name"] + "\n")
 
             return projects
 

--- a/github.py
+++ b/github.py
@@ -205,17 +205,31 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
 
         params = {"sort": "updated", "per_page": min(max_repos, 100), "type": "all"}
 
-        status_code, repos_data = _fetch_github_api(api_url, params=params)
+        status_code, repos_list = _fetch_github_api(api_url, params=params)
 
         if status_code == 200:
             projects = []
-            for repo in repos_data:
-                if repo.get("fork") and repo.get("forks_count", 0) < 5:
-                    continue
+            for repo in repos_list:
+                repo_details_source = repo
+                repo_owner = username
 
-                repo_name = repo.get("name")
+                is_forked = repo_details_source.get("fork", False)
+                
+                if is_forked:
+                    # second call to get parent data
+                    detail_status, detailed_repo_data = _fetch_github_api(repo["url"])
 
-                contributors_data = fetch_repo_contributors(username, repo_name)
+                    if detail_status == 200 and "parent" in detailed_repo_data:
+                        if detailed_repo_data["parent"].get("forks_count", 0) < 5:
+                            print(f"-> Skipping fork '{repo['name']}' as parent has less than 5 forks.")
+                            continue
+                    repo_details_source = detailed_repo_data.get("parent")
+                    repo_owner = repo_details_source["owner"].get("login")
+                    
+
+                repo_name = repo_details_source.get("name")
+
+                contributors_data = fetch_repo_contributors(repo_owner, repo_name)
                 contributor_count = len(contributors_data)
 
                 user_contributions, total_contributions = fetch_contributions_count(
@@ -225,32 +239,32 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
                 project_type = (
                     "open_source" if contributor_count > 1 else "self_project"
                 )
-
+                
                 project = {
                     "name": repo.get("name"),
                     "description": repo.get("description"),
                     "github_url": repo.get("html_url"),
-                    "live_url": repo.get("homepage") if repo.get("homepage") else None,
+                    "live_url": repo_details_source.get("homepage") if repo_details_source.get("homepage") else None,
                     "technologies": (
-                        [repo.get("language")] if repo.get("language") else []
+                        [repo_details_source.get("language")] if repo_details_source.get("language") else []
                     ),
                     "project_type": project_type,
                     "contributor_count": contributor_count,
                     "author_commit_count": user_contributions,
                     "total_commit_count": total_contributions,
                     "github_details": {
-                        "stars": repo.get("stargazers_count", 0),
-                        "forks": repo.get("forks_count", 0),
-                        "language": repo.get("language"),
-                        "description": repo.get("description"),
-                        "created_at": repo.get("created_at"),
-                        "updated_at": repo.get("updated_at"),
-                        "topics": repo.get("topics", []),
-                        "open_issues": repo.get("open_issues_count", 0),
-                        "size": repo.get("size", 0),
-                        "fork": repo.get("fork", False),
-                        "archived": repo.get("archived", False),
-                        "default_branch": repo.get("default_branch"),
+                        "stars": repo_details_source.get("stargazers_count", 0),
+                        "forks": repo_details_source.get("forks_count", 0),
+                        "language": repo_details_source.get("language"),
+                        "description": repo_details_source.get("description"),
+                        "created_at": repo_details_source.get("created_at"),
+                        "updated_at": repo_details_source.get("updated_at"),
+                        "topics": repo_details_source.get("topics", []),
+                        "open_issues": repo_details_source.get("open_issues_count", 0),
+                        "size": repo_details_source.get("size", 0),
+                        "fork": is_forked,
+                        "archived": repo_details_source.get("archived", False),
+                        "default_branch": repo_details_source.get("default_branch"),
                         "contributors": contributor_count,
                     },
                 }
@@ -269,13 +283,19 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
             print(
                 f"📊 Project classification: {open_source_count} open source, {self_project_count} self projects"
             )
+            
+            print("Open Source Repos => ")
+            for project in projects:
+                if(project["project_type"] == "open_source"):
+                    print(project["name"] + "\n")
+
             return projects
 
         elif status_code == 404:
             print(f"GitHub user not found: {username}")
             return []
         else:
-            print(f"GitHub API error: {status_code} - {repos_data}")
+            print(f"GitHub API error: {status_code} - {repos_list}")
             return []
 
     except requests.exceptions.RequestException as e:


### PR DESCRIPTION
## Description
This PR implements the correct logic for handling forked repositories.

When a repository is a fork, its stats (stars, forks, description) are often not what we want to display. This implementation correctly fetches the parent repository's details by making a second API call to the repo's specific URL.

It then uses the parent's stats (stargazers_count, forks_count, description, etc.) for building the final project object. This ensures that contributions to popular open-source projects are accurately represented.

This PR also includes a small fix to ensure the parent's description is used for the project, not the fork's.

## Before
![first-hackerrank](https://github.com/user-attachments/assets/64714e58-67b9-42b6-a7d7-763c9184d0ca)

## After
![second-hackerrank](https://github.com/user-attachments/assets/cc756752-0f19-4a79-a238-8d49e162ee08)

#### Fixes : #155 