### PR TITLE
Add quoting to CSV writer in score.py

### DIFF
--- a/score.py
+++ b/score.py
@@ -284,7 +284,7 @@ def main(pdf_path):
 
         with open(csv_path, "a", newline="", encoding="utf-8") as csvfile:
             fieldnames = list(csv_row.keys())
-            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames, quoting=csv.QUOTE_ALL)
 
             # Write headers if file doesn't exist
             if not file_exists:


### PR DESCRIPTION
This branch addresses an issue in the CSV output where multiple links (such as GitHub, LinkedIn, etc.) were being merged into a single cell/link due to improper CSV quoting. The fix ensures that all fields containing commas or URLs are properly enclosed in quotes, preserving the correct column structure and readability.

This branch includes:
Improved handling of CSV writing using csv.QUOTE_ALL