### PR TITLE
fix: add mapping for newer gemini models (fixes  issue #194 ) 

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -39,6 +39,8 @@ MODEL_PARAMETERS = {
     "gemini-2.5-pro": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
+    "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -57,6 +59,8 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-flash": ModelProvider.GEMINI,
     "gemini-2.5-flash-lite": ModelProvider.GEMINI,
     "gemini-2.5-pro": ModelProvider.GEMINI,
+    "gemini-3.5-flash": ModelProvider.GEMINI,
+    "gemini-3.1-flash-lite": ModelProvider.GEMINI,
 }
 
 # Get API keys from environment


### PR DESCRIPTION
### Description
This PR fixes the issue where newer Gemini models (like `gemini-3.5-flash` and `gemini-3.1-flash-lite`) silently fell back to the `OllamaProvider` because they were missing from the `MODEL_PROVIDER_MAPPING`. They are now explicitly mapped to the `GeminiProvider`.
### Before
The script failed to recognize the model and threw a local Ollama connection error:
```text
2026-06-03 12:27:58,865 - llm_utils - INFO - 🔄 Using Ollama provider with model gemini-3.5-flash
2026-06-03 12:28:01,205 - pdf - ERROR - ❌ Error calling LLM for basics section: Failed to connect to Ollama. Please check that Ollama is downloaded, running and accessible.
```
### After
The script correctly identifies the model as a Gemini model, uses the `GeminiProvider`, and successfully hits the Google APIs:
```text
2026-06-03 12:31:13,583 - llm_utils -    58 -           initialize_llm_provider -  INFO - 🔄 Using Google Gemini API provider with model gemini-3.5-flash
2026-06-03 12:31:47,776 -   pdf -   313 -  _extract_all_sections_separately -  INFO - ⏱️ Total time for separate section extraction: 33.74 seconds
```
**Note on Model Selection:**
I intentionally only added the current, stable Gemini models (`gemini-3.5-flash` and `gemini-3.1-flash-lite`). I avoided adding any speculative or `-preview` tagged models (like `gemini-3.0-pro` or `gemini-3.5-pro-preview`) to ensure stability. Including unstable model names could lead to `404 Not Found` API errors for users until those models are officially promoted to stable.