### PR TITLE
fix: prevent UnicodeEncodeError on non-UTF-8 consoles and fix eval log level

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -79,7 +79,7 @@ class ResumeEvaluator:
 
             response_text = response["message"]["content"]
             response_text = extract_json_from_response(response_text)
-            logger.error(f"🔤 Prompt response: {response_text}")
+            logger.debug(f"🔤 Prompt response: {response_text}")
 
             evaluation_dict = json.loads(response_text)
             evaluation_data = EvaluationData(**evaluation_dict)

--- a/score.py
+++ b/score.py
@@ -20,6 +20,14 @@ from config import DEVELOPMENT_MODE
 
 logger = logging.getLogger(__name__)
 
+# Force UTF-8 on stdout/stderr so emoji in print() and log messages don't crash
+# on consoles with a non-UTF-8 default codec (e.g. Windows cp1252), which would
+# otherwise raise UnicodeEncodeError and abort the run.
+for _stream in (sys.stdout, sys.stderr):
+    _reconfigure = getattr(_stream, "reconfigure", None)
+    if _reconfigure is not None:
+        _reconfigure(encoding="utf-8", errors="replace")
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)5s - %(lineno)5d - %(funcName)33s - %(levelname)5s - %(message)s",


### PR DESCRIPTION
## What

Fixes two issues that make a healthy run (any provider, but most visibly Gemini) look like a failure.

### 1. `UnicodeEncodeError` aborts the run on non-UTF-8 consoles
On a Windows console (default **cp1252** codec), the pipeline crashes as soon as an emoji is printed — e.g. the `🔍 Fetching all repository details...` line in `github.py` — with:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f50d'
```

This aborts the whole run before any results are shown, and is independent of the LLM provider. Fixed by reconfiguring `stdout`/`stderr` to UTF-8 at startup in `score.py`. The block is a no-op where `reconfigure` is unavailable or the stream already encodes UTF-8.

### 2. Successful LLM response logged at `ERROR` level
`evaluator.py` logged the parsed LLM response with `logger.error(...)`, so a perfectly successful evaluation printed a red `ERROR` line, reinforcing the impression that the provider had failed. Downgraded to `logger.debug`.

## How verified

- Reproduced the crash by forcing `PYTHONIOENCODING=cp1252` and printing the emoji — fails without the fix, succeeds with it.
- Ran the full pipeline end-to-end with `LLM_PROVIDER=gemini` / `gemini-2.5-flash`: Gemini returns a valid, fully-scored evaluation.
- `py_compile` passes on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
