### PR TITLE
fix(models): handle Gemini API rate limit with exponential backoff / …

### DIFF
--- a/models.py
+++ b/models.py
@@ -327,6 +327,15 @@ class GeminiProvider:
         **kwargs
     ) -> Dict[str, Any]:
         """Send a chat request to Google Gemini API."""
+        import re
+        import time
+        import random
+        from google.api_core.exceptions import ResourceExhausted
+
+        MAX_RETRIES = 5
+        BASE_DELAY = 10.0  # seconds — base for exponential backoff
+        MAX_DELAY = 120.0  # cap so we never wait more than 2 minutes
+
         # Map options to Gemini parameters
         generation_config = {}
         if options:
@@ -346,8 +355,37 @@ class GeminiProvider:
             role = "user" if msg["role"] == "user" else "model"
             gemini_messages.append({"role": role, "parts": [msg["content"]]})
 
-        # Send the chat request
-        response = gemini_model.generate_content(gemini_messages)
+        for attempt in range(MAX_RETRIES):
+            try:
+                # Send the chat request
+                response = gemini_model.generate_content(gemini_messages)
 
-        # Convert Gemini response to Ollama-like format for compatibility
-        return {"message": {"role": "assistant", "content": response.text}}
+                # Convert Gemini response to Ollama-like format for compatibility
+                return {"message": {"role": "assistant", "content": response.text}}
+
+            except ResourceExhausted as e:
+                if attempt == MAX_RETRIES - 1:
+                    # All retries exhausted — re-raise the original exception.
+                    # This surfaces unrecoverable quota errors (RPD, TPM, etc.)
+                    # instead of silently failing or returning bad data.
+                    raise
+
+                # Parse the API-suggested retry delay from the error message
+                match = re.search(r"retry[_ ]in\s+([\d.]+)s", str(e), re.IGNORECASE)
+                api_hint = float(match.group(1)) if match else None
+
+                # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
+                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+
+                # Prefer the API hint when it is shorter than our computed delay
+                delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay
+
+                # Add ±20% randomized jitter to avoid thundering herd
+                sleep_time = round(delay * random.uniform(0.8, 1.2), 2)
+
+                print(
+                    f"[GeminiProvider] Rate limit hit "
+                    f"(attempt {attempt + 1}/{MAX_RETRIES}). "
+                    f"Retrying in {sleep_time}s..."
+                )
+                time.sleep(sleep_time)


### PR DESCRIPTION
## 📝 Description
This PR introduces automatic rate-limit handling for the `GeminiProvider` to prevent the application from crashing when utilizing the Gemini API free tier.

## ❓ Why is this needed?
Google Gemini's free tier has a strict rate limit of **5 Requests Per Minute (RPM)** in some regions. Because the `hiring-agent` script evaluates a resume by extracting 6 separate sections in rapid succession (*basics, work, education, skills, projects, and awards*), it easily exhausts the 5 RPM limit on the final section. This previously resulted in a `429 ResourceExhausted` exception and a failed run.

## 🛠️ What was changed?
* **Updated `models.py`:** Modified the `GeminiProvider.chat` method.
* **Added Error Handling:** Implemented a `try/except` block to catch the `google.api_core.exceptions.ResourceExhausted` exception.
* **Fallback Logic:** When the rate limit is hit, the script now prints a warning, proactively sleeps for **60 seconds** to let the quota reset, and automatically retries the API call.

## 🧪 How to test

1. Configure your `.env` file to use the Gemini provider and a free-tier API key:
```env
   LLM_PROVIDER=gemini
   GEMINI_API_KEY=your_free_tier_key_here