### PR TITLE
fix: drop Ollama JSON-schema format constraint that emptied resume sections

### DIFF
--- a/pdf.py
+++ b/pdf.py
@@ -99,12 +99,15 @@ class PDFHandler:
                 },
             }
 
-            kwargs = {}
-            if return_model:
-                kwargs["format"] = return_model.model_json_schema()
-
+            # NOTE: We intentionally do NOT pass the Pydantic JSON schema as a
+            # grammar `format` constraint. Small Ollama models (e.g. gemma3:4b)
+            # satisfy the constraint by returning an empty `{}`, silently dropping
+            # whole sections (work/skills/awards). The prompts already require
+            # valid JSON, and extract_json_from_response() handles markdown fences,
+            # so prompt-only extraction is far more reliable. (Gemini ignores
+            # `format` anyway.) `return_model` is kept for documentation/validation.
             # Use the appropriate provider to make the API call
-            response = self.provider.chat(**chat_params, **kwargs)
+            response = self.provider.chat(**chat_params)
 
             response_text = response["message"]["content"]
 


### PR DESCRIPTION
Fixes #202

## Problem

On the default local setup (`ollama` + `gemma3:4b`), entire resume sections — **work, skills, awards** — are silently dropped during extraction. The run logs `⚠️ Failed to extract work section` and continues with empty data, so scoring is computed against missing information (e.g. real work experience is scored as "no production experience").

The LLM call does **not** error — it returns HTTP 200 with an empty object `{}`.

## Root cause

`PDFHandler._call_llm_for_section` passed each section's Pydantic schema to Ollama as a grammar `format` constraint:

```python
kwargs = {}
if return_model:
    kwargs["format"] = return_model.model_json_schema()
response = self.provider.chat(**chat_params, **kwargs)
```

Every field in the section models is `Optional` (e.g. `WorkSection.work: Optional[List[Work]] = None`), so an empty `{}` is a valid instance of the schema. Under grammar-constrained decoding, a small model takes the shortest legal path and emits `{}`. It parses as JSON without error, but contains no data, and `if section_data:` then treats it as a failed extraction.

## Fix

Stop passing the schema as a `format` constraint. The prompts already require valid JSON, and `extract_json_from_response()` already strips markdown code fences, so prompt-only extraction is reliable across model sizes. `GeminiProvider.chat` ignores `format` entirely, so this changes only the Ollama path.

## Before / After

Same model, same prompt — the only difference is the `format` constraint:

**Before** (`format=schema`):
```
{}
```

**After** (prompt-only):
```json
{"work": [{"name": "ExampleCorp", "position": "Software Engineer", "startDate": "June 2025", "endDate": "March 2026"}]}
```

Impact on a real resume with one SWE role + one internship:

| Category | Before | After |
|---|---|---|
| Production Experience | 10/25 | 20/25 |
| "Failed to extract" warnings | work, skills, awards | none |

## Testing

Ran the full pipeline end-to-end with Ollama / `gemma3:4b` before and after; all sections now extract and no "Failed to extract" warnings appear.

Added a local regression test (provider mocked, no server needed) asserting that (a) a fenced `{"work": [...]}` response is parsed and (b) the provider is no longer called with a `format` constraint. Note: the repo's `.gitignore` currently ignores `test_*.py` and `tests/`, so the test isn't included in this PR — happy to add it if you'd like `tests/` un-ignored.

## Related

#192 / #198 address invalid cache persistence (the downstream symptom — null values written to cache). This PR fixes the upstream root cause so extraction succeeds in the first place. Complementary, not overlapping.