### PR TITLE
feat: add OpenAI-compatible provider for LM Studio, vLLM, and others

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,9 @@
-# LLM Provider Configuration
-# Options: "ollama" or "gemini"
 LLM_PROVIDER=ollama
-
-# Default model to use
-# For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
-# For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
 DEFAULT_MODEL=gemma3:4b
 
-# Google Gemini API Key (required if using Gemini provider)
+# Required when LLM_PROVIDER=gemini
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# Required when LLM_PROVIDER=openai
+# Works with LM Studio, vLLM, llama.cpp, LocalAI, or any OpenAI-compatible server
+OPENAI_BASE_URL=http://localhost:1234/v1

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Overview
 
-Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use Google Gemini.
+Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama, use any OpenAI-compatible server (LM Studio, vLLM, llama.cpp, LocalAI), or use Google Gemini.
 
 ---
 
@@ -85,10 +85,12 @@ Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a lo
 
   The repository pins `.python-version` to 3.11.13.
 
-- **One LLM backend** (either of them)
+- **One LLM backend** (any of these)
 
   - **Ollama** for local models
     Install from the [official site](https://ollama.com/), then run `ollama serve`.
+  - **Any OpenAI-compatible server** ([LM Studio](https://lmstudio.ai/), [vLLM](https://docs.vllm.ai/), [llama.cpp server](https://github.com/ggerganov/llama.cpp), [LocalAI](https://localai.io/), etc.)
+    Start your server and note the base URL it reports.
   - **Google Gemini** if you have an API key, get it from [here](https://aistudio.google.com/api-keys).
 
 ### Quick setup with pip
@@ -136,12 +138,13 @@ $ cp .env.example .env
 
 **Environment variables**
 
-| Variable         | Values                                      | Description                                                            |
-| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
-| `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
-| `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
+| Variable         | Values                                             | Description                                                            |
+| ---------------- | -------------------------------------------------- | ---------------------------------------------------------------------- |
+| `LLM_PROVIDER`   | `ollama`, `gemini`, or `openai`                    | Chooses provider. Defaults to Ollama.                                  |
+| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro`        | Model name passed to the provider.                                     |
+| `GEMINI_API_KEY` | string                                             | Required when `LLM_PROVIDER=gemini`.                                   |
+| `OPENAI_BASE_URL`| URL, default `http://localhost:1234/v1`            | Base URL for the OpenAI-compatible server. Required when `LLM_PROVIDER=openai`. |
+| `GITHUB_TOKEN`   | optional                                           | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
 
@@ -265,6 +268,14 @@ What happens:
 - Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
+
+### OpenAI-compatible
+
+- Set `LLM_PROVIDER=openai`
+- Set `DEFAULT_MODEL` to the model identifier your server reports (check your server's UI or `/v1/models` endpoint)
+- Set `OPENAI_BASE_URL` to your server's base URL (default: `http://localhost:1234/v1`)
+- Works with [LM Studio](https://lmstudio.ai/), [vLLM](https://docs.vllm.ai/), [llama.cpp server](https://github.com/ggerganov/llama.cpp), [LocalAI](https://localai.io/), and any OpenAI-compatible endpoint
+- The wrapper in `models.OpenAICompatibleProvider` uses the `openai` Python SDK and adapts responses to the unified format
 
 ---
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -3,8 +3,14 @@ Utility functions for LLM providers.
 """
 
 import logging
+import os
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
+from models import (
+    ModelProvider,
+    OllamaProvider,
+    GeminiProvider,
+    OpenAICompatibleProvider,
+)
 from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
 
 logger = logging.getLogger(__name__)
@@ -45,8 +51,20 @@ def initialize_llm_provider(model_name: str) -> Any:
         model_name: The name of the model to use
 
     Returns:
-        An initialized LLM provider (either OllamaProvider or GeminiProvider)
+        An initialized LLM provider (OllamaProvider, GeminiProvider, or
+        OpenAICompatibleProvider)
     """
+    # Check LLM_PROVIDER env var first for the OpenAI-compatible provider,
+    # since its model names are not in MODEL_PROVIDER_MAPPING.
+    llm_provider_env = os.getenv("LLM_PROVIDER", "ollama").lower()
+
+    if llm_provider_env == "openai":
+        base_url = os.getenv("OPENAI_BASE_URL", "http://localhost:1234/v1")
+        logger.info(
+            f"🔄 Using OpenAI-compatible provider at {base_url} with model {model_name}"
+        )
+        return OpenAICompatibleProvider(base_url=base_url)
+
     # Default to Ollama provider
     provider = OllamaProvider()
     # If using Gemini and API key is available, use Gemini provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    OPENAI = "openai"
 
 
 @runtime_checkable
@@ -351,3 +352,49 @@ class GeminiProvider:
 
         # Convert Gemini response to Ollama-like format for compatibility
         return {"message": {"role": "assistant", "content": response.text}}
+
+
+class OpenAICompatibleProvider:
+    """Provider for any OpenAI-compatible API endpoint.
+
+    Works with LM Studio, vLLM, llama.cpp server, LocalAI, and any other
+    service that exposes an OpenAI-compatible chat completions endpoint.
+    """
+
+    def __init__(self, base_url: str = "http://localhost:1234/v1"):
+        from openai import OpenAI
+
+        self.client = OpenAI(base_url=base_url, api_key="not-needed")
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Send a chat request to an OpenAI-compatible endpoint."""
+        params: Dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+        }
+
+        if options:
+            if "temperature" in options:
+                params["temperature"] = options["temperature"]
+            if "top_p" in options:
+                params["top_p"] = options["top_p"]
+
+        # Map format="json" to OpenAI-style response_format
+        if kwargs.get("format") == "json":
+            params["response_format"] = {"type": "json_object"}
+
+        response = self.client.chat.completions.create(**params)
+
+        # Return in the same shape as OllamaProvider and GeminiProvider
+        return {
+            "message": {
+                "role": "assistant",
+                "content": response.choices[0].message.content,
+            }
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pymupdf4llm==0.0.27
 Jinja2==3.1.6
 google-generativeai==0.4.0
 python-dotenv==1.0.1
-black==25.9.0
+black==25.9.0openai>=1.0.0


### PR DESCRIPTION
## Summary

Adds a third LLM provider (`openai`) that works with any service exposing an OpenAI-compatible chat completions endpoint. This covers LM Studio, vLLM, llama.cpp server, LocalAI, and similar tools — letting users run the pipeline against models they already have downloaded without installing Ollama or obtaining a Gemini API key.

## Motivation

The current provider options are Ollama (local) and Gemini (cloud). Many developers already run local models through LM Studio or vLLM, which expose OpenAI-compatible HTTP APIs. Supporting these endpoints directly avoids forcing users to re-download models into Ollama's separate storage and broadens the set of usable backends with minimal code.

## Changes

| File | What changed |
|---|---|
| `models.py` | Added `OPENAI = "openai"` to `ModelProvider` enum. Added `OpenAICompatibleProvider` class using the `openai` Python SDK, mapping `format="json"` to `response_format` and returning the same dict shape as the existing providers. |
| `llm_utils.py` | `initialize_llm_provider` now checks `LLM_PROVIDER` env var for `openai` before falling through to the existing Ollama/Gemini logic. Added `import os` and `OpenAICompatibleProvider` import. |
| `requirements.txt` | Added `openai>=1.0.0`. |
| `.env.example` | Added `OPENAI_BASE_URL` variable with a comment listing compatible backends. |
| `README.md` | Added OpenAI-compatible section under **Provider details**, a row in the **Environment variables** table, and a bullet under **Prerequisites**. |

## Usage

```bash
# .env
LLM_PROVIDER=openai
DEFAULT_MODEL=gemma-4-12b-it-qat   # must match the model identifier in your server
OPENAI_BASE_URL=http://localhost:1234/v1   # LM Studio default; adjust for vLLM, etc.
```

```bash
python score.py /path/to/resume.pdf
```

## Testing

Validated end-to-end on a real resume with:

- **LM Studio** (macOS, Apple Silicon M2, 16 GB) serving Gemma 4 12B Instruct QAT (Q4_K_XL)
- Context length set to 24,000 tokens
- All 6 section extraction calls returned `200 OK` with valid JSON
- GitHub enrichment and final evaluation completed successfully
- Total extraction time: ~119 seconds, full pipeline: ~5 minutes

Existing Ollama and Gemini code paths are unchanged — the new provider branch is only entered when `LLM_PROVIDER=openai`.