### PR TITLE
feat: add OpenAI API provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,15 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "openai"
 LLM_PROVIDER=ollama
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For OpenAI: "gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini", etc.
 DEFAULT_MODEL=gemma3:4b
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# OpenAI API Key (required if using OpenAI provider)
+OPENAI_API_KEY=your_openai_api_key_here

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,8 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import ModelProvider, OllamaProvider, GeminiProvider, OpenAIProvider
+from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY, OPENAI_API_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -45,18 +45,27 @@ def initialize_llm_provider(model_name: str) -> Any:
         model_name: The name of the model to use
 
     Returns:
-        An initialized LLM provider (either OllamaProvider or GeminiProvider)
+        An initialized LLM provider (OllamaProvider, GeminiProvider, or OpenAIProvider).
+        Falls back to OllamaProvider if the required API key is missing.
     """
     # Default to Ollama provider
     provider = OllamaProvider()
-    # If using Gemini and API key is available, use Gemini provider
+    # If using Gemini or OpenAI and API key is available, use the respective provider
     model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
+
     if model_provider == ModelProvider.GEMINI:
         if not GEMINI_API_KEY:
             logger.warning("⚠️ Gemini API key not found. Falling back to Ollama.")
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.OPENAI:
+        if not OPENAI_API_KEY:
+            logger.warning("⚠️ OpenAI API key not found. Falling back to Ollama.")
+        else:
+            logger.info(f"🔄 Using OpenAI API provider with model {model_name}")
+            provider = OpenAIProvider(api_key=OPENAI_API_KEY)
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
+
     return provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    OPENAI = "openai"
 
 
 @runtime_checkable
@@ -351,3 +352,39 @@ class GeminiProvider:
 
         # Convert Gemini response to Ollama-like format for compatibility
         return {"message": {"role": "assistant", "content": response.text}}
+
+
+class OpenAIProvider:
+    """OpenAI API provider implementation."""
+
+    def __init__(self, api_key: str):
+        from openai import OpenAI
+
+        self.client = OpenAI(api_key=api_key)
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Send a chat request to OpenAI."""
+        params: Dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+        }
+
+        if options:
+            if "temperature" in options:
+                params["temperature"] = options["temperature"]
+            if "top_p" in options:
+                params["top_p"] = options["top_p"]
+
+        # Support structured JSON output via response_format
+        if "format" in kwargs and isinstance(kwargs["format"], dict):
+            params["response_format"] = {"type": "json_object"}
+
+        response = self.client.chat.completions.create(**params)
+        content = response.choices[0].message.content
+        return {"message": {"role": "assistant", "content": content}}

--- a/prompt.py
+++ b/prompt.py
@@ -41,6 +41,12 @@ MODEL_PARAMETERS = {
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # OpenAI models
+    "gpt-4o": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-4o-mini": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-4.1": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-4.1-mini": {"temperature": 0.1, "top_p": 0.9},
+    "o3-mini": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -61,7 +67,14 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
+    # OpenAI models
+    "gpt-4o": ModelProvider.OPENAI,
+    "gpt-4o-mini": ModelProvider.OPENAI,
+    "gpt-4.1": ModelProvider.OPENAI,
+    "gpt-4.1-mini": ModelProvider.OPENAI,
+    "o3-mini": ModelProvider.OPENAI,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pymupdf4llm==0.0.27
 Jinja2==3.1.6
 google-generativeai==0.4.0
 python-dotenv==1.0.1
+openai>=1.0.0
 black==25.9.0


### PR DESCRIPTION
Closes #208

## Summary
- Adds `OpenAIProvider` class implementing the existing `LLMProvider` protocol
- Adds `ModelProvider.OPENAI` enum value
- Registers OpenAI models (`gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`, `o3-mini`) in model mappings
- Adds `OPENAI_API_KEY` env var support — falls back to Ollama if key is not set
- Ollama remains the default provider, no breaking changes

## How to use
Set in `.env`:
\`\`\`
LLM_PROVIDER=openai
DEFAULT_MODEL=gpt-4o-mini
OPENAI_API_KEY=sk-...
\`\`\`

## Test plan
- [x] Runs with `DEFAULT_MODEL=gpt-4o-mini` and valid `OPENAI_API_KEY`
- [x] Falls back to Ollama when `OPENAI_API_KEY` is missing
- [x] Existing Ollama and Gemini flows unchanged