### PR TITLE
bug: add blog post fetching and integration into resume evaluation workf

### DIFF
--- a/blog.py
+++ b/blog.py
@@ -1,0 +1,114 @@
+import os
+import json
+import re
+import requests
+import xml.etree.ElementTree as ET
+from typing import Dict, Optional, List
+from pathlib import Path
+
+def extract_username(url: str, platform: str) -> Optional[str]:
+    url = url.strip().rstrip('/')
+    if platform == "dev.to":
+        match = re.search(r'dev\.to/([^/]+)', url)
+        return match.group(1) if match else None
+    elif platform == "medium":
+        match = re.search(r'medium\.com/@([^/]+)', url)
+        if match: return match.group(1)
+        match = re.search(r'([^/]+)\.medium\.com', url)
+        if match and match.group(1) != "www": return match.group(1)
+        return None
+    elif platform == "hashnode":
+        match = re.search(r'hashnode\.com/@([^/]+)', url)
+        if match: return match.group(1)
+        match = re.search(r'([^/]+)\.hashnode\.dev', url)
+        if match: return match.group(1)
+        return None
+    return None
+
+def fetch_devto_blogs(username: str) -> List[Dict]:
+    try:
+        response = requests.get(f"https://dev.to/api/articles?username={username}", timeout=10)
+        if response.status_code == 200:
+            articles = response.json()
+            blogs = []
+            for art in articles[:5]:
+                blogs.append({
+                    "url": art.get("url"),
+                    "score": "N/A",
+                    "details": f"Title: {art.get('title', '')}\nDescription: {art.get('description', '')}"
+                })
+            return blogs
+    except Exception as e:
+        print(f"Error fetching dev.to blogs: {e}")
+    return []
+
+def fetch_rss_blogs(feed_url: str) -> List[Dict]:
+    try:
+        response = requests.get(feed_url, timeout=10)
+        if response.status_code == 200:
+            root = ET.fromstring(response.content)
+            blogs = []
+            for item in root.findall('./channel/item')[:5]:
+                title = item.find('title').text if item.find('title') is not None else ""
+                link = item.find('link').text if item.find('link') is not None else ""
+                
+                categories = [c.text for c in item.findall('category')]
+                cat_text = f"Tags: {', '.join(categories)}" if categories else ""
+                
+                blogs.append({
+                    "url": link,
+                    "score": "N/A",
+                    "details": f"Title: {title}\n{cat_text}"
+                })
+            return blogs
+    except Exception as e:
+        print(f"Error fetching RSS blogs from {feed_url}: {e}")
+    return []
+
+def identify_platform(url: str) -> Optional[str]:
+    url = url.lower()
+    if "dev.to" in url: return "dev.to"
+    if "medium.com" in url: return "medium"
+    if "hashnode.com" in url or "hashnode.dev" in url: return "hashnode"
+    return None
+
+def fetch_and_display_blog_info(url: str) -> Dict:
+    platform = identify_platform(url)
+    if not platform:
+        print(f"Unrecognized blog platform for URL: {url}")
+        return {}
+
+    username = extract_username(url, platform)
+    if not username:
+        print(f"Could not extract username from {platform} URL: {url}")
+        return {}
+
+    print(f"🔍 Fetching blog articles from {platform} for user {username}...")
+    
+    blogs = []
+    if platform == "dev.to":
+        blogs = fetch_devto_blogs(username)
+    elif platform == "medium":
+        # Medium feed is usually medium.com/feed/@username
+        blogs = fetch_rss_blogs(f"https://medium.com/feed/@{username}")
+    elif platform == "hashnode":
+        # Hashnode feed
+        if "hashnode.dev" in url:
+            blogs = fetch_rss_blogs(f"https://{username}.hashnode.dev/rss.xml")
+        else:
+            blogs = fetch_rss_blogs(f"https://hashnode.com/@{username}/rss")
+
+    if not blogs:
+        print(f"❌ No articles found on {platform} for {username}")
+        return {}
+
+    print(f"✅ Found {len(blogs)} recent articles on {platform}")
+
+    result = {
+        "total_blogs": len(blogs),
+        "blog_score": "N/A",
+        "blog_details": f"Fetched {len(blogs)} articles from {platform}",
+        "blogs": blogs
+    }
+
+    return result

--- a/score.py
+++ b/score.py
@@ -5,6 +5,7 @@ import logging
 import csv
 from pdf import PDFHandler
 from github import fetch_and_display_github_info
+from blog import fetch_and_display_blog_info
 from models import JSONResume, EvaluationData
 from typing import List, Optional, Dict
 from evaluator import ResumeEvaluator
@@ -205,6 +206,9 @@ def main(pdf_path):
     github_cache_filename = (
         f"cache/githubcache_{os.path.basename(pdf_path).replace('.pdf', '')}.json"
     )
+    blog_cache_filename = (
+        f"cache/blogcache_{os.path.basename(pdf_path).replace('.pdf', '')}.json"
+    )
 
     # Check if cache exists and we're in development mode
     if DEVELOPMENT_MODE and os.path.exists(cache_filename):
@@ -255,7 +259,44 @@ def main(pdf_path):
                 encoding='utf-8'
             )
 
-    score = _evaluate_resume(resume_data, github_data)
+    blog_data = {}
+    if DEVELOPMENT_MODE and os.path.exists(blog_cache_filename):
+        print(f"Loading cached blog data from {blog_cache_filename}")
+        blog_data = json.loads(Path(blog_cache_filename).read_text())
+    else:
+        print(
+            f"Fetching blog data"
+            + (" and caching to " + blog_cache_filename if DEVELOPMENT_MODE else "")
+        )
+
+        profiles = []
+        if resume_data and hasattr(resume_data, "basics") and resume_data.basics:
+            profiles = resume_data.basics.profiles or []
+
+        blog_profile = None
+        for network in ["Medium", "Dev.to", "DEV Community", "Hashnode"]:
+            blog_profile = find_profile(profiles, network)
+            if blog_profile:
+                break
+                
+        # If no explicit network matched, check the urls in all profiles
+        if not blog_profile:
+            for p in profiles:
+                if p.url and ("medium.com" in p.url.lower() or "dev.to" in p.url.lower() or "hashnode.com" in p.url.lower() or "hashnode.dev" in p.url.lower()):
+                    blog_profile = p
+                    break
+
+        if blog_profile and blog_profile.url:
+            blog_data = fetch_and_display_blog_info(blog_profile.url)
+
+        if DEVELOPMENT_MODE:
+            os.makedirs(os.path.dirname(blog_cache_filename), exist_ok=True)
+            Path(blog_cache_filename).write_text(
+                json.dumps(blog_data, indent=2, ensure_ascii=False),
+                encoding='utf-8'
+            )
+
+    score = _evaluate_resume(resume_data, github_data, blog_data)
 
     # Get candidate name for display
     candidate_name = os.path.basename(pdf_path).replace(".pdf", "")


### PR DESCRIPTION
# Fix: Integrate Blog Data Fetching and Evaluation

## Description
This PR fixes a critical gap in the ATS evaluation pipeline where candidate blog posts and technical writing were completely ignored. Although the `_evaluate_resume` function was designed to accept a `blog_data` parameter, the `main()` execution block lacked the logic to extract the profile, fetch the data, and pass it to the evaluator.

## Changes Made
* **Profile Extraction:** Added logic to search `resume_data.basics.profiles` for recognized blogging platforms (e.g., Medium, Hashnode, Dev.to).
* **Data Fetching:** Implemented the missing `fetch_and_display_blog_info(url)` integration to retrieve the candidate's article history.
* **Development Caching:** Added a new `blogcache_{name}.json` cache file to respect the `DEVELOPMENT_MODE` environment, preventing rate-limiting during local testing.
* **Function Call Update:** Modified the final evaluation execution to correctly pass all contexts: `score = _evaluate_resume(resume_data, github_data, blog_data)`.

## Why this matters
By successfully feeding the blog data into the AI evaluator, the script can now accurately score candidates on their technical communication skills and domain expertise, ensuring a much fairer and more comprehensive resume evaluation.

## Related Issues
Closes #209