### PR TITLE
[feature] Add support to configure role and organization through .env parameters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ DEFAULT_MODEL=gemma3:4b
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# Resume evaluation context
+RESUME_EVALUATION_ROLE=Software Engineer Intern
+RESUME_EVALUATION_ORGANIZATION=HackerRank

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ $ cp .env.example .env
 | `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
 | `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
 | `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
+| `RESUME_EVALUATION_ROLE` | for example `Software Engineer Intern` | Role used in the resume evaluation criteria prompt. Defaults to `Software Engineer Intern`. |
+| `RESUME_EVALUATION_ORGANIZATION` | for example `HackerRank` | Organization used in the resume evaluation criteria prompt. Defaults to `HackerRank`. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -15,6 +15,8 @@ from prompt import (
     MODEL_PARAMETERS,
     MODEL_PROVIDER_MAPPING,
     GEMINI_API_KEY,
+    RESUME_EVALUATION_ORGANIZATION,
+    RESUME_EVALUATION_ROLE,
 )
 from prompts.template_manager import TemplateManager
 
@@ -39,7 +41,10 @@ class ResumeEvaluator:
 
     def _load_evaluation_prompt(self, resume_text: str) -> str:
         criteria_template = self.template_manager.render_template(
-            "resume_evaluation_criteria", text_content=resume_text
+            "resume_evaluation_criteria",
+            text_content=resume_text,
+            role=RESUME_EVALUATION_ROLE,
+            organization=RESUME_EVALUATION_ORGANIZATION,
         )
         if criteria_template is None:
             raise ValueError("Failed to load resume evaluation criteria template")

--- a/prompt.py
+++ b/prompt.py
@@ -15,6 +15,8 @@ load_dotenv()
 # Constants
 DEFAULT_MODEL_NAME = "gemma3:4b"
 DEFAULT_PROVIDER = ModelProvider.OLLAMA
+DEFAULT_RESUME_EVALUATION_ROLE = "Software Engineer Intern"
+DEFAULT_RESUME_EVALUATION_ORGANIZATION = "HackerRank"
 
 # Get model and provider from environment or use defaults
 DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", DEFAULT_MODEL_NAME)
@@ -65,3 +67,11 @@ MODEL_PROVIDER_MAPPING = {
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+
+# Resume evaluation context
+RESUME_EVALUATION_ROLE = os.getenv(
+    "RESUME_EVALUATION_ROLE", DEFAULT_RESUME_EVALUATION_ROLE
+)
+RESUME_EVALUATION_ORGANIZATION = os.getenv(
+    "RESUME_EVALUATION_ORGANIZATION", DEFAULT_RESUME_EVALUATION_ORGANIZATION
+)

--- a/prompts/templates/resume_evaluation_criteria.jinja
+++ b/prompts/templates/resume_evaluation_criteria.jinja
@@ -1,4 +1,10 @@
-You are evaluating a resume for a Software Intern position at HackerRank. Analyze the resume data and provide scores based on these criteria:
+You are evaluating a resume for the {{ role }} role at {{ organization }}.
+
+Evaluation context:
+- Role: {{ role }}
+- Organization: {{ organization }}
+
+Analyze the resume data and provide scores based on these criteria:
 
 **MANDATORY: You MUST always fill ALL FOUR categories: open_source, self_projects, production, technical_skills.**
 


### PR DESCRIPTION
## Summary
- Replace the hardcoded resume evaluation role and organization in the Jinja template with template variables.
- Load RESUME_EVALUATION_ROLE and RESUME_EVALUATION_ORGANIZATION from the environment with defaults defined in application code.
- Pass the evaluation context into the template and document the new .env settings.

## Tests
- python3 template render smoke check with default role/organization
- RESUME_EVALUATION_ROLE='Data Scientist' RESUME_EVALUATION_ORGANIZATION='Acme Corp' python3 template render smoke check
- python3 -m py_compile prompt.py evaluator.py prompts/template_manager.py
- python3 -m black --check prompt.py evaluator.py (could not run: black is not installed in the local Python environment)

Closes #189