### PR TITLE
feat: add Sarvam AI LLM provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,16 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "sarvam"
 LLM_PROVIDER=ollama
 
 # Default model to use
-# For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
+# For Ollama: "gemma3:4b", "qwen3:4b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For Sarvam: "sarvam-30b" (64K context), "sarvam-105b" (128K context)
 DEFAULT_MODEL=gemma3:4b
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# Sarvam AI API Subscription Key (required if using Sarvam provider)
+SARVAM_API_KEY=your_sarvam_api_key_here
+

--- a/README.md
+++ b/README.md
@@ -138,9 +138,10 @@ $ cp .env.example .env
 
 | Variable         | Values                                      | Description                                                            |
 | ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
+| `LLM_PROVIDER`   | `ollama`, `gemini`, or `sarvam`              | Chooses provider. Defaults to Ollama.                                  |
+| `DEFAULT_MODEL`  | e.g. `gemma3:4b`, `gemini-2.5-pro`, or `sarvam-30b` | Model name passed to the provider.                              |
 | `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
+| `SARVAM_API_KEY` | string                                      | Required when `LLM_PROVIDER=sarvam`.                                   |
 | `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
@@ -265,6 +266,15 @@ What happens:
 - Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
+
+### Sarvam AI
+
+- Set `LLM_PROVIDER=sarvam`
+- Set `DEFAULT_MODEL` to a supported Sarvam AI model:
+  - `sarvam-30b`: High-performance multilingual LLM (64K context window)
+  - `sarvam-105b`: Flagship model with advanced reasoning capabilities (128K context window)
+- Provide `SARVAM_API_KEY` (subscription key)
+- The wrapper in `models.SarvamProvider` integrates with the official `sarvamai` SDK and handles transient failures/rate-limiting proactively
 
 ---
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -78,6 +78,8 @@ class ResumeEvaluator:
             response = self.provider.chat(**chat_params, **kwargs)
 
             response_text = response["message"]["content"]
+            if response_text is None:
+                raise ValueError("LLM returned empty content for evaluation")
             response_text = extract_json_from_response(response_text)
             logger.error(f"🔤 Prompt response: {response_text}")
 

--- a/github.py
+++ b/github.py
@@ -43,48 +43,61 @@ def _fetch_github_api(api_url, params=None):
 
     response = requests.get(api_url, params, timeout=10, headers=headers)
     status_code = response.status_code
-    
+
     # Check GitHub rate limit headers
     rate_limit_remaining = response.headers.get("X-RateLimit-Remaining")
     rate_limit_limit = response.headers.get("X-RateLimit-Limit")
     rate_limit_reset = response.headers.get("X-RateLimit-Reset")
-    logger.info(f"{rate_limit_remaining}/{rate_limit_limit}. Reset at {rate_limit_reset}")
-    
+    logger.info(
+        f"{rate_limit_remaining}/{rate_limit_limit}. Reset at {rate_limit_reset}"
+    )
+
     if rate_limit_remaining is not None and rate_limit_limit is not None:
         remaining = int(rate_limit_remaining)
         limit = int(rate_limit_limit)
-        
+
         # Log rate limit information and handle proactively
         if remaining < 10 and rate_limit_reset:
             reset_timestamp = int(rate_limit_reset)
             current_timestamp = int(time.time())
-            wait_seconds = max(0, reset_timestamp - current_timestamp) + 5  # Add 5 second buffer
+            wait_seconds = (
+                max(0, reset_timestamp - current_timestamp) + 5
+            )  # Add 5 second buffer
             reset_time = datetime.datetime.fromtimestamp(reset_timestamp)
-            
+
             # Cap maximum wait time at 1 hour
             max_wait = 3600
             if wait_seconds > max_wait:
-                print(f"⚠️  Rate limit reset time is too far in the future ({wait_seconds}s). Capping wait to {max_wait}s")
+                print(
+                    f"⚠️  Rate limit reset time is too far in the future ({wait_seconds}s). Capping wait to {max_wait}s"
+                )
                 wait_seconds = max_wait
-            
-            logger.error(f"⚠️  GitHub API rate limit low: {remaining}/{limit} requests remaining. Resets at {reset_time}")
-            print(f"💡 Tip: Set GITHUB_TOKEN environment variable to increase rate limits (60/hour → 5000/hour)")
-            
+
+            logger.error(
+                f"⚠️  GitHub API rate limit low: {remaining}/{limit} requests remaining. Resets at {reset_time}"
+            )
+            print(
+                f"💡 Tip: Set GITHUB_TOKEN environment variable to increase rate limits (60/hour → 5000/hour)"
+            )
+
             if wait_seconds > 0:
-                logger.info(f"⏳ Proactively sleeping for {wait_seconds} seconds until rate limit resets...")
+                logger.info(
+                    f"⏳ Proactively sleeping for {wait_seconds} seconds until rate limit resets..."
+                )
                 time.sleep(wait_seconds)
                 print(f"✅ Rate limit should be reset now. Continuing...")
         elif remaining < 100:
-            logger.info(f"ℹ️  GitHub API rate limit: {remaining}/{limit} requests remaining")
-    
+            logger.info(
+                f"ℹ️  GitHub API rate limit: {remaining}/{limit} requests remaining"
+            )
+
     data = response.json() if response.status_code == 200 else {}
 
     if DEVELOPMENT_MODE and status_code == 200:
         try:
             os.makedirs("cache", exist_ok=True)
             Path(cache_filename).write_text(
-                json.dumps(data, indent=2, ensure_ascii=False),
-                encoding='utf-8'
+                json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
             )
         except Exception as e:
             logger.error(f"Error caching GitHub data to {cache_filename}: {e}")
@@ -373,6 +386,8 @@ def generate_projects_json(projects: List[Dict]) -> List[Dict]:
         response_text = response["message"]["content"]
 
         try:
+            if response_text is None:
+                raise ValueError("LLM returned empty content")
             response_text = response_text.strip()
             response_text = extract_json_from_response(response_text)
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,8 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import ModelProvider, OllamaProvider, GeminiProvider, SarvamProvider
+from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY, SARVAM_API_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ def initialize_llm_provider(model_name: str) -> Any:
         model_name: The name of the model to use
 
     Returns:
-        An initialized LLM provider (either OllamaProvider or GeminiProvider)
+        An initialized LLM provider (either OllamaProvider, GeminiProvider, or SarvamProvider)
     """
     # Default to Ollama provider
     provider = OllamaProvider()
@@ -57,6 +57,12 @@ def initialize_llm_provider(model_name: str) -> Any:
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.SARVAM:
+        if not SARVAM_API_KEY:
+            logger.warning("⚠️ Sarvam API key not found. Falling back to Ollama.")
+        else:
+            logger.info(f"🔄 Using Sarvam AI API provider with model {model_name}")
+            provider = SarvamProvider(api_key=SARVAM_API_KEY)
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
     return provider

--- a/models.py
+++ b/models.py
@@ -1,6 +1,10 @@
 from typing import List, Optional, Dict, Tuple, Any, Protocol, runtime_checkable
 from pydantic import BaseModel, Field, field_validator
 from enum import Enum
+import time
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ModelProvider(Enum):
@@ -8,6 +12,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    SARVAM = "sarvam"
 
 
 @runtime_checkable
@@ -19,7 +24,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -281,7 +286,7 @@ class OllamaProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -324,9 +329,9 @@ class GeminiProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
-        """Send a chat request to Google Gemini API."""
+        """Send a chat request to Google Gemini API with automatic rate limit / quota retry."""
         # Map options to Gemini parameters
         generation_config = {}
         if options:
@@ -346,8 +351,105 @@ class GeminiProvider:
             role = "user" if msg["role"] == "user" else "model"
             gemini_messages.append({"role": role, "parts": [msg["content"]]})
 
-        # Send the chat request
-        response = gemini_model.generate_content(gemini_messages)
+        max_retries = 8
+        base_delay = 10
+        for attempt in range(max_retries):
+            try:
+                # Send the chat request
+                response = gemini_model.generate_content(gemini_messages)
+                return {"message": {"role": "assistant", "content": response.text}}
+            except Exception as e:
+                # If we're out of attempts, raise
+                if attempt == max_retries - 1:
+                    raise e
 
-        # Convert Gemini response to Ollama-like format for compatibility
-        return {"message": {"role": "assistant", "content": response.text}}
+                # Check if it's a rate limit or quota issue
+                err_str = str(e).lower()
+                if (
+                    "quota" in err_str
+                    or "429" in err_str
+                    or "exhausted" in err_str
+                    or "rate limit" in err_str
+                ):
+                    delay = base_delay * (2**attempt)
+                    logger.warning(
+                        f"⚠️ Gemini API quota exceeded or rate limit hit. Retrying in {delay} seconds (attempt {attempt + 1}/{max_retries})..."
+                    )
+                    time.sleep(delay)
+                else:
+                    raise e
+
+
+class SarvamProvider:
+    """Sarvam AI API provider implementation using the official sarvamai SDK.
+
+    Supported models (as of 2026):
+        - sarvam-30b: High-performance multilingual LLM (64K context window)
+        - sarvam-105b: Flagship model with advanced reasoning (128K context window)
+
+    Authentication is via the `api-subscription-key` parameter.
+    See: https://docs.sarvam.ai/
+    """
+
+    def __init__(self, api_key: str):
+        from sarvamai import SarvamAI
+
+        self.client = SarvamAI(api_subscription_key=api_key)
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Send a chat request to Sarvam AI via the official SDK with automatic retry."""
+        # Build the completion kwargs
+        completion_kwargs: Dict[str, Any] = {
+            "model": model,
+            "messages": [
+                {"role": msg["role"], "content": msg["content"]} for msg in messages
+            ],
+        }
+
+        if options:
+            if "temperature" in options:
+                completion_kwargs["temperature"] = options["temperature"]
+            if "top_p" in options:
+                completion_kwargs["top_p"] = options["top_p"]
+
+        max_retries = 8
+        base_delay = 5
+        for attempt in range(max_retries):
+            try:
+                response = self.client.chat.completions(**completion_kwargs)
+                content = response.choices[0].message.content
+                return {"message": {"role": "assistant", "content": content}}
+            except Exception as e:
+                if attempt == max_retries - 1:
+                    raise e
+
+                err_str = str(e).lower()
+                is_retryable = any(
+                    keyword in err_str
+                    for keyword in [
+                        "429",
+                        "rate limit",
+                        "quota",
+                        "500",
+                        "502",
+                        "503",
+                        "504",
+                        "timeout",
+                        "connection",
+                    ]
+                )
+                if is_retryable:
+                    delay = base_delay * (2**attempt)
+                    logger.warning(
+                        f"Sarvam AI API error (attempt {attempt + 1}/{max_retries}): {e}. "
+                        f"Retrying in {delay}s..."
+                    )
+                    time.sleep(delay)
+                else:
+                    raise e

--- a/pdf.py
+++ b/pdf.py
@@ -109,6 +109,10 @@ class PDFHandler:
             response_text = response["message"]["content"]
 
             try:
+                if response_text is None:
+                    raise ValueError(
+                        f"LLM returned empty content for {section_name} section"
+                    )
                 response_text = extract_json_from_response(response_text)
                 json_start = response_text.find("{")
                 json_end = response_text.rfind("}")

--- a/prompt.py
+++ b/prompt.py
@@ -39,6 +39,9 @@ MODEL_PARAMETERS = {
     "gemini-2.5-pro": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # Sarvam AI models (https://docs.sarvam.ai/)
+    "sarvam-30b": {"temperature": 0.1, "top_p": 0.9},  # 64K context
+    "sarvam-105b": {"temperature": 0.1, "top_p": 0.9},  # 128K context
 }
 
 # Model provider mapping
@@ -57,7 +60,11 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-flash": ModelProvider.GEMINI,
     "gemini-2.5-flash-lite": ModelProvider.GEMINI,
     "gemini-2.5-pro": ModelProvider.GEMINI,
+    # Sarvam AI models (https://docs.sarvam.ai/)
+    "sarvam-30b": ModelProvider.SARVAM,
+    "sarvam-105b": ModelProvider.SARVAM,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+SARVAM_API_KEY = os.getenv("SARVAM_API_KEY", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ requests==2.32.4
 pymupdf4llm==0.0.27
 Jinja2==3.1.6
 google-generativeai==0.4.0
+sarvamai>=0.1.28
 python-dotenv==1.0.1
 black==25.9.0


### PR DESCRIPTION
Integrates Sarvam AI as a third provider option alongside Ollama and Gemini. Installs sarvamai SDK, implements SarvamProvider in models.py, maps sarvam-30b and sarvam-105b models in prompt.py, and fixes empty LLM content handling in github.py, pdf.py, and evaluator.py. Docs updated in README.md and .env.example.