### PR TITLE
fix: pass system message as system_instruction for Gemini provider

### DIFF
--- a/models.py
+++ b/models.py
@@ -335,16 +335,28 @@ class GeminiProvider:
             if "top_p" in options:
                 generation_config["top_p"] = options["top_p"]
 
-        # Create a Gemini model
-        gemini_model = self.client.GenerativeModel(
-            model_name=model, generation_config=generation_config
-        )
-
-        # Convert messages to Gemini format
+        # Gemini does not accept a "system" role in the contents list and requires
+        # the first content to be a "user" turn. Pull any system messages out and
+        # pass them through system_instruction instead of dropping/mislabeling them.
+        system_instruction = None
         gemini_messages = []
         for msg in messages:
+            if msg["role"] == "system":
+                system_instruction = (
+                    msg["content"]
+                    if system_instruction is None
+                    else system_instruction + "\n\n" + msg["content"]
+                )
+                continue
             role = "user" if msg["role"] == "user" else "model"
             gemini_messages.append({"role": role, "parts": [msg["content"]]})
+
+        # Create a Gemini model
+        gemini_model = self.client.GenerativeModel(
+            model_name=model,
+            generation_config=generation_config,
+            system_instruction=system_instruction,
+        )
 
         # Send the chat request
         response = gemini_model.generate_content(gemini_messages)


### PR DESCRIPTION
## What's wrong

The Gemini provider is broken for every call that uses a system message, which is all of them (extraction in `pdf.py`, project selection in `github.py`, evaluation in `evaluator.py` all pass a `system` role message as the first message).

In `GeminiProvider.chat` the role mapping is:

```python
for msg in messages:
    role = "user" if msg["role"] == "user" else "model"
    gemini_messages.append({"role": role, "parts": [msg["content"]]})
```

So the `system` message gets relabeled as a `model` turn and stays at the front of the `contents` list. Gemini's `generate_content` requires the first turn to be `user` and doesn't accept a `system` role at all, so the call raises something like:

```
Please ensure that the first content is from the user, ...
```

On top of the hard failure, the system prompt (the scoring rules, fairness constraints, "select 7 unique projects" instruction, etc.) is silently thrown away even in cases where the call wouldn't error. The Ollama path is unaffected because Ollama accepts the `system` role directly.

Net effect: one of the two documented providers doesn't run.

## The fix

Pull system messages out of the `contents` list and pass them through `GenerativeModel(system_instruction=...)`, which is the supported way to give Gemini a system prompt. Remaining user/model turns are mapped as before. If more than one system message is present they're concatenated.

## Before / after

Before (system message becomes a leading `model` turn → rejected):

```python
gemini_messages = []
for msg in messages:
    role = "user" if msg["role"] == "user" else "model"
    gemini_messages.append({"role": role, "parts": [msg["content"]]})

gemini_model = self.client.GenerativeModel(
    model_name=model, generation_config=generation_config
)
response = gemini_model.generate_content(gemini_messages)
```

After (system message routed to `system_instruction`, first turn is `user`):

```python
system_instruction = None
gemini_messages = []
for msg in messages:
    if msg["role"] == "system":
        system_instruction = (
            msg["content"]
            if system_instruction is None
            else system_instruction + "\n\n" + msg["content"]
        )
        continue
    role = "user" if msg["role"] == "user" else "model"
    gemini_messages.append({"role": role, "parts": [msg["content"]]})

gemini_model = self.client.GenerativeModel(
    model_name=model,
    generation_config=generation_config,
    system_instruction=system_instruction,
)
response = gemini_model.generate_content(gemini_messages)
```

## Testing

- `python -m black --check models.py` passes.
- Verified the contents list now starts with a `user` turn and the system text is handed to `system_instruction` rather than dropped.

No changes to the Ollama path or to any prompts/templates.

Fixes #342