### PR TITLE
fix: read GitHub stats from profile dict for CSV export

### DIFF
--- a/transform.py
+++ b/transform.py
@@ -657,11 +657,14 @@ def transform_evaluation_response(
 
     # Extract GitHub data
     if github_data:
-        csv_row["github_repos"] = github_data.get("public_repos", 0)
-        csv_row["github_followers"] = github_data.get("followers", 0)
-        csv_row["github_following"] = github_data.get("following", 0)
-        csv_row["github_created_at"] = github_data.get("created_at", "")
-        csv_row["github_bio"] = github_data.get("bio", "")
+        # Profile stats live under github_data["profile"] (see
+        # github.fetch_and_display_github_info), not at the top level.
+        github_profile_data = github_data.get("profile", {})
+        csv_row["github_repos"] = github_profile_data.get("public_repos", 0)
+        csv_row["github_followers"] = github_profile_data.get("followers", 0)
+        csv_row["github_following"] = github_profile_data.get("following", 0)
+        csv_row["github_created_at"] = github_profile_data.get("created_at", "")
+        csv_row["github_bio"] = github_profile_data.get("bio", "")
     else:
         csv_row["github_repos"] = 0
         csv_row["github_followers"] = 0


### PR DESCRIPTION
Fixes #216.

## Problem

In dev mode `score.py` appends a CSV row per resume via `transform_evaluation_response`. The GitHub columns (`github_repos`, `github_followers`, `github_following`, `github_created_at`, `github_bio`) always come out as `0`/empty, even when the profile was fetched fine.

`fetch_and_display_github_info` returns the profile stats nested under a `"profile"` key:

```python
{"profile": {"public_repos": ..., "followers": ..., ...}, "projects": [...], "total_projects": N}
```

but `transform_evaluation_response` read them off the top level, so every lookup fell through to its default. `convert_github_data_to_text` in the same file already reads from `github_data["profile"]`, so this was just an inconsistency in one function.

## Fix

Read the stats from `github_data["profile"]`.

```python
github_profile_data = github_data.get("profile", {})
csv_row["github_repos"]      = github_profile_data.get("public_repos", 0)
csv_row["github_followers"]  = github_profile_data.get("followers", 0)
csv_row["github_following"]  = github_profile_data.get("following", 0)
csv_row["github_created_at"] = github_profile_data.get("created_at", "")
csv_row["github_bio"]        = github_profile_data.get("bio", "")
```

`.get("profile", {})` keeps it safe when GitHub data is absent (falls back to the same defaults as before).

## Testing

- `python -m black --check transform.py` passes.
- Verified against the dict shape returned by `fetch_and_display_github_info`: the columns now resolve to the real profile values instead of the defaults.
