### PR TITLE
fix: paginate repo contributors so counts aren't capped at 30

### DIFF
--- a/github.py
+++ b/github.py
@@ -203,12 +203,29 @@ def fetch_repo_contributors(owner: str, repo_name: str) -> list[dict]:
     try:
         api_url = f"https://api.github.com/repos/{owner}/{repo_name}/contributors"
 
-        status_code, contributors_data = _fetch_github_api(api_url)
+        # The /contributors endpoint is paginated (30 per page by default).
+        # Without paging we only ever see the first 30 contributors, which
+        # understates contributor_count/total_commit_count and can wrongly
+        # classify popular repos. Request 100 per page and follow pages until
+        # a short (or empty) page is returned.
+        per_page = 100
+        max_pages = 10  # safety cap: up to 1000 contributors
+        all_contributors: list[dict] = []
 
-        if status_code == 200:
-            return contributors_data
-        else:
-            return []
+        for page in range(1, max_pages + 1):
+            params = {"per_page": per_page, "page": page}
+            status_code, contributors_data = _fetch_github_api(api_url, params=params)
+
+            if status_code != 200 or not isinstance(contributors_data, list):
+                break
+
+            all_contributors.extend(contributors_data)
+
+            # Last page reached when fewer than a full page is returned.
+            if len(contributors_data) < per_page:
+                break
+
+        return all_contributors
 
     except Exception as e:
         logger.error(f"Error fetching contributors for {owner}/{repo_name}: {e}")


### PR DESCRIPTION
Fixes #217.

## Problem

`fetch_repo_contributors` made a single call to the GitHub `/contributors` endpoint and returned `response.json()`. That endpoint paginates at 30 results per page by default, so for any repo with more than 30 contributors we only ever saw the first 30. That feeds:

- `contributor_count = len(contributors_data)` → capped at 30
- `total_commit_count` → summed over only the first 30 contributors
- `project_type` (`open_source` vs `self_project`) → derived from the capped count
- `author_commit_count` → can end up 0 if the author isn't on the first page, and a 0 here makes `generate_projects_json` drop the project entirely

These all flow into the `open_source` / `self_projects` scoring, so the numbers were wrong for popular repos.

## Fix

Request `per_page=100` and follow pages until a short page comes back, capped at 10 pages (up to 1000 contributors) as a safety bound:

```python
per_page = 100
max_pages = 10
all_contributors = []
for page in range(1, max_pages + 1):
    params = {"per_page": per_page, "page": page}
    status_code, contributors_data = _fetch_github_api(api_url, params=params)
    if status_code != 200 or not isinstance(contributors_data, list):
        break
    all_contributors.extend(contributors_data)
    if len(contributors_data) < per_page:
        break
return all_contributors
```

Caching still works per page because `_create_cache_filename` includes the params (including `page`) in the cache file name.

## Notes / trade-off

This adds at most one extra request for repos with <=100 contributors (the common case), and more only for repos that genuinely have many contributors. The 10-page cap bounds the cost for very large repos; if you'd prefer a different cap I'm happy to adjust.

## Testing

- `python -m black --check github.py` passes.
- Logic verified against the GitHub pagination contract (30/page default, short final page terminates the loop).
