### PR TITLE
fix: handle failed resume evaluation gracefully

### DIFF
--- a/score.py
+++ b/score.py
@@ -180,12 +180,17 @@ def _evaluate_resume(
         blog_text = convert_blog_data_to_text(blog_data)
         resume_text += blog_text
 
-    # Evaluate the enhanced resume
-    evaluation_result = evaluator.evaluate_resume(resume_text)
-
-    # print(evaluation_result)
-
-    return evaluation_result
+    # Evaluate the enhanced resume. If the provider returns malformed output or
+    # fails mid-request, keep the run alive and let callers record N/A scores.
+    try:
+        return evaluator.evaluate_resume(resume_text)
+    except Exception as exc:
+        logger.error(
+            "Resume evaluation failed; skipping AI score for this resume. Reason: %s",
+            exc,
+        )
+        logger.debug("Evaluation failure details", exc_info=True)
+        return None
 
 
 def is_valid_resume_data(resume_data: JSONResume) -> bool:

--- a/tests/evaluation_failure_test.py
+++ b/tests/evaluation_failure_test.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch
+
+import score
+
+
+class FailingEvaluator:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def evaluate_resume(self, resume_text):
+        raise ValueError("invalid model response")
+
+
+class EvaluationFailureTest(unittest.TestCase):
+    def test_evaluate_resume_returns_none_when_evaluator_fails(self):
+        with (
+            patch.object(score, "ResumeEvaluator", FailingEvaluator),
+            patch.object(score, "convert_json_resume_to_text", return_value="resume"),
+            self.assertLogs(score.logger, level="ERROR") as logs,
+        ):
+            result = score._evaluate_resume(resume_data=object())
+
+        self.assertIsNone(result)
+        self.assertTrue(
+            any("Resume evaluation failed" in message for message in logs.output)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- catch resume evaluation failures in the score wrapper instead of letting them terminate the run
- keep parsed resume and enrichment work usable when the final LLM evaluation fails
- add a focused unittest covering the failure path

## Root cause
Issue #196 happens because evaluator.py re-raises provider, parsing, and validation failures, while score.py called the evaluator without handling those exceptions. A malformed LLM response or provider error could therefore abort the entire command after parsing and enrichment had already succeeded.

## Validation
- .venv/bin/python -m unittest discover -s tests -p "*_test.py"
- .venv/bin/python -m py_compile score.py tests/evaluation_failure_test.py
- .venv/bin/python -m black --check score.py tests/evaluation_failure_test.py

Closes #196