### PR TITLE
Add Claude Code CLI as LLM provider (no API key needed)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "claude_code"
 LLM_PROVIDER=ollama
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For Claude Code CLI (no API key needed): "claude-code"
 DEFAULT_MODEL=gemma3:4b
 
 # Google Gemini API Key (required if using Gemini provider)

--- a/CLAUDE_CODE_GUIDE.md
+++ b/CLAUDE_CODE_GUIDE.md
@@ -1,0 +1,121 @@
+# Running Hiring Agent with Claude Code as the LLM
+
+No API key needed. This guide uses the `claude` CLI you already have installed.
+
+---
+
+## Prerequisites
+
+- Python 3.11+
+- Claude Code installed and logged in (`claude` command works in your terminal)
+- A resume PDF to evaluate
+
+---
+
+## Step 1 — Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## Step 2 — Create your `.env` file
+
+Copy the example and set the Claude Code provider:
+
+```bash
+cp .env.example .env
+```
+
+Then open `.env` and set it to exactly this:
+
+```
+LLM_PROVIDER=claude_code
+DEFAULT_MODEL=claude-code
+GEMINI_API_KEY=
+```
+
+Optionally add a GitHub token to avoid rate limiting when the resume has a GitHub profile:
+
+```
+GITHUB_TOKEN=your_github_pat_here
+```
+
+---
+
+## Step 3 — Verify the Claude CLI works
+
+Run this in your terminal to confirm the `claude` binary is reachable:
+
+```bash
+claude -p "say hello"
+```
+
+You should get a short reply. If you get `command not found`, Claude Code is not on your PATH — restart your terminal or reinstall Claude Code.
+
+---
+
+## Step 4 — Run the evaluator
+
+```bash
+python score.py path/to/resume.pdf
+```
+
+Example:
+
+```bash
+python score.py resumes/john_doe.pdf
+```
+
+---
+
+## What happens when you run it
+
+1. **PDF → Markdown** — the resume is parsed page by page
+2. **Section extraction** — the Claude CLI is called once per resume section (basics, work, education, skills, projects, awards) to extract structured JSON
+3. **GitHub enrichment** — if a GitHub URL is found in the resume, repos are fetched and scored
+4. **Evaluation** — a fairness-constrained score is produced (max 120 pts)
+5. **Output** — a readable report is printed to your terminal
+
+Since `DEVELOPMENT_MODE = True` in `config.py`:
+- Intermediate results are cached in `cache/` — subsequent runs on the same PDF are much faster
+- A row is appended to `resume_evaluations.csv` after each run
+
+---
+
+## Scoring breakdown
+
+| Category         | Max pts |
+|------------------|---------|
+| Open source      | 35      |
+| Self projects    | 30      |
+| Production work  | 25      |
+| Technical skills | 10      |
+| Bonus            | 20      |
+| **Total**        | **120** |
+
+Deductions apply for tutorial-only projects, missing links, or Hacktoberfest-only contributions.
+
+---
+
+## Tips
+
+**Speed up re-runs** — caching is on by default. Delete files in `cache/` to force a fresh extraction.
+
+**Turn off caching** — set `DEVELOPMENT_MODE = False` in `config.py` if you want a clean run every time without CSV export either.
+
+**The LLM is called many times per resume** — each section is a separate `claude -p` call, so a full evaluation takes a few minutes. This is normal.
+
+**Claude Code must stay logged in** — if your session expires, run `claude` interactively once to re-authenticate, then re-run the evaluator.
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `command not found: claude` | Restart terminal; reinstall Claude Code if needed |
+| `RuntimeError: Claude Code CLI returned exit code 1` | Run `claude -p "test"` manually to check your login status |
+| JSON parse errors in output | Usually a one-off; delete the cached file and re-run — the extraction will retry |
+| GitHub rate limit warnings | Add `GITHUB_TOKEN=<your_pat>` to `.env` |

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,7 +4,7 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
+from models import ModelProvider, OllamaProvider, GeminiProvider, ClaudeCodeProvider
 from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
 
 logger = logging.getLogger(__name__)
@@ -49,7 +49,6 @@ def initialize_llm_provider(model_name: str) -> Any:
     """
     # Default to Ollama provider
     provider = OllamaProvider()
-    # If using Gemini and API key is available, use Gemini provider
     model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
     if model_provider == ModelProvider.GEMINI:
         if not GEMINI_API_KEY:
@@ -57,6 +56,9 @@ def initialize_llm_provider(model_name: str) -> Any:
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.CLAUDE_CODE:
+        logger.info("🔄 Using Claude Code CLI provider (no API key required)")
+        provider = ClaudeCodeProvider()
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
     return provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    CLAUDE_CODE = "claude_code"
 
 
 @runtime_checkable
@@ -308,6 +309,53 @@ class OllamaProvider:
             chat_params["format"] = kwargs["format"]
 
         return self.client.chat(**chat_params)
+
+
+class ClaudeCodeProvider:
+    """LLM provider that calls the Claude Code CLI as a subprocess.
+
+    Requires no API key — uses the existing `claude` CLI authentication.
+    Run `claude` in your terminal to confirm you are logged in before using this.
+    """
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Send a chat request via the `claude -p` CLI."""
+        import subprocess
+
+        # Build a single prompt: system message first, then user messages
+        parts = []
+        for m in messages:
+            if m["role"] == "system":
+                parts.append(m["content"])
+            else:
+                parts.append(m["content"])
+        prompt = "\n\n".join(parts)
+
+        # When the caller wants a JSON response, make that explicit in the prompt
+        if kwargs.get("format") == "json":
+            prompt += "\n\nReturn valid JSON only. No markdown fences, no explanation text."
+
+        cmd = ["claude", "-p", prompt]
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Claude Code CLI returned exit code {result.returncode}:\n{result.stderr}"
+            )
+
+        return {"message": {"role": "assistant", "content": result.stdout.strip()}}
 
 
 class GeminiProvider:

--- a/prompt.py
+++ b/prompt.py
@@ -41,6 +41,8 @@ MODEL_PARAMETERS = {
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # Claude Code CLI — no API key needed, uses local `claude` CLI login
+    "claude-code": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -61,6 +63,8 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
+    # Claude Code CLI
+    "claude-code": ModelProvider.CLAUDE_CODE,
 }
 
 # Get API keys from environment


### PR DESCRIPTION
Adds a new `ClaudeCodeProvider` that uses the `claude -p` CLI as a subprocess, allowing users to run the hiring agent with zero API keys - as long as they have Claude Code installed and logged in.

- Adds `CLAUDE_CODE` to the `ModelProvider` enum in `models.py`
- Implements `ClaudeCodeProvider` class that calls `claude -p <prompt>` via subprocess
- Wires up the provider in `llm_utils.py`, `prompt.py`, and `.env.example`
- Adds `CLAUDE_CODE_GUIDE.md` - a step-by-step guide for users who want to run with this provider