### PR TITLE
feat: expand supported Gemini model list and validate DEFAULT_MODEL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,16 @@ LLM_PROVIDER=ollama
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
-# For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For Gemini, supported IDs are:
+#   gemini-2.0-flash, gemini-2.0-flash-lite
+#   gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite
+#   gemini-3-flash-preview, gemini-3.1-pro-preview
+#   gemini-3.5-flash, gemini-3.1-flash-lite
 DEFAULT_MODEL=gemma3:4b
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# GitHub token (optional): raises API rate limit from 60/hour to 5000/hour.
+# Generate at https://github.com/settings/tokens
+GITHUB_TOKEN=your_github_token_here

--- a/README.md
+++ b/README.md
@@ -262,7 +262,14 @@ What happens:
 ### Gemini
 
 - Set `LLM_PROVIDER=gemini`
-- Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
+- Set `DEFAULT_MODEL` to a supported Gemini model. Supported IDs:
+  - `gemini-2.0-flash`, `gemini-2.0-flash-lite`
+  - `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`
+  - `gemini-3-flash-preview`, `gemini-3.1-pro-preview`
+  - `gemini-3.5-flash`, `gemini-3.1-flash-lite`
+- If `DEFAULT_MODEL` is not one of the supported Gemini IDs, startup fails with an
+  error listing the supported models. To add a new one, register it in
+  `MODEL_PARAMETERS` and `MODEL_PROVIDER_MAPPING` in `prompt.py`.
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
 

--- a/prompt.py
+++ b/prompt.py
@@ -39,6 +39,8 @@ MODEL_PARAMETERS = {
     "gemini-2.5-pro": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    "gemini-3-flash-preview": {"temperature": 0.1, "top_p": 0.9},
+    "gemini-3.1-pro-preview": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
 }
@@ -59,9 +61,31 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-flash": ModelProvider.GEMINI,
     "gemini-2.5-flash-lite": ModelProvider.GEMINI,
     "gemini-2.5-pro": ModelProvider.GEMINI,
+    "gemini-3-flash-preview": ModelProvider.GEMINI,
+    "gemini-3.1-pro-preview": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+
+# Supported Gemini model IDs (derived from the mapping above)
+SUPPORTED_GEMINI_MODELS = [
+    model
+    for model, provider in MODEL_PROVIDER_MAPPING.items()
+    if provider == ModelProvider.GEMINI
+]
+
+# Validate the configured Gemini model so unknown IDs fail loudly with a helpful
+# message instead of silently falling back to Ollama (see
+# llm_utils.initialize_llm_provider, which defaults unknown models to Ollama).
+if PROVIDER == ModelProvider.GEMINI.value and (
+    MODEL_PROVIDER_MAPPING.get(DEFAULT_MODEL) != ModelProvider.GEMINI
+):
+    raise ValueError(
+        f"DEFAULT_MODEL '{DEFAULT_MODEL}' is not a supported Gemini model.\n"
+        f"Supported Gemini models: {', '.join(SUPPORTED_GEMINI_MODELS)}.\n"
+        "To use a newer model, register it in MODEL_PARAMETERS and "
+        "MODEL_PROVIDER_MAPPING in prompt.py."
+    )


### PR DESCRIPTION
## Problem

The hardcoded Gemini model list in `prompt.py` (`MODEL_PARAMETERS` and `MODEL_PROVIDER_MAPPING`) was behind the current Google Gemini API model list. Setting `DEFAULT_MODEL` to a newer model (e.g. `gemini-3.1-pro-preview`) was not supported out of the box, and there was no validation or helpful error — the model silently fell back to the Ollama provider in `llm_utils.initialize_llm_provider`.

## Changes

- **`prompt.py`**: Register newer Gemini models (`gemini-3-flash-preview`, `gemini-3.1-pro-preview`) in `MODEL_PARAMETERS` and `MODEL_PROVIDER_MAPPING`, alongside the existing 2.0/2.5/3.x IDs.
- **`prompt.py`**: Add startup validation — when `LLM_PROVIDER=gemini` and `DEFAULT_MODEL` is not a recognized Gemini model, raise a clear `ValueError` listing the supported IDs instead of silently falling back to Ollama. Ollama stays permissive so any pulled model still works.
- **`.env.example`** and **`README.md`**: Document the current supported Gemini model IDs.

## Behavior

Before — unknown Gemini model silently routed to Ollama:
```
DEFAULT_MODEL=gemini-3.1-pro-preview  ->  silently uses Ollama provider, confusing failure
```

After — valid model works; unknown model fails fast:
```
DEFAULT_MODEL=gemini-3.1-pro-preview  ->  OK
DEFAULT_MODEL=gemini-9-ultra          ->  ValueError: '...' is not a supported Gemini model.
                                          Supported Gemini models: gemini-2.0-flash, ...
```

## Testing

- `import prompt` with a valid Gemini model (`gemini-3.1-pro-preview`) succeeds.
- `import prompt` with an unknown Gemini model raises a clear error listing supported IDs.
- Ollama provider remains permissive: arbitrary pulled model names still load.
- `black prompt.py` reports no formatting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
