### PR TITLE
fix: skip empty optional sections instead of aborting extraction

### DIFF
--- a/pdf.py
+++ b/pdf.py
@@ -286,17 +286,30 @@ class PDFHandler:
             "meta": None,
         }
 
+        # Only `basics` (candidate identity) is treated as required. Every other
+        # section is optional: many resumes legitimately omit them, and under the
+        # schema `format` constraint a small model can return an empty `{}` for any
+        # section (issue #202) -- if those were required, the abort this change
+        # fixes would still fire for them. An empty optional section is skipped
+        # (with a warning) instead of discarding every section extracted so far.
+        required_sections = {"basics"}
+
         for section_name in sections:
             section_data = self._extract_section_data(text_content, section_name)
 
             if section_data:
                 complete_resume.update(section_data)
                 logger.debug(f"✅ Successfully extracted {section_name} section")
-            else:
+            elif section_name in required_sections:
                 logger.error(
-                    f"⚠️ Failed to extract {section_name} section. Aborting extraction to prevent partial/invalid resume data."
+                    f"⚠️ Failed to extract required '{section_name}' section. "
+                    "Aborting extraction to prevent invalid resume data."
                 )
                 return None
+            else:
+                logger.warning(
+                    f"ℹ️ No '{section_name}' section found (optional). Skipping."
+                )
 
         try:
             if complete_resume.get("basics") and isinstance(


### PR DESCRIPTION
## What

`_extract_all_sections_separately` now aborts only when the required identity section (`basics`) comes back empty. Empty optional sections (`skills`/`projects`/`awards`) are skipped with a warning, so one empty optional section no longer discards the rest of the parse.

Closes #226.

## Why

Today, any one empty section `return None`s the whole extraction, throwing away every section already pulled. That's wrong for optional sections (resumes commonly omit `awards`/`projects`), and it amplifies #202: under the schema `format` constraint a small Ollama model can return `{}` for a section, which then nukes the other 5 successfully-extracted sections. #203 removes the most common cause of `{}` but leaves this abort path in place.

This change aligns extraction with the existing downstream guard `is_valid_resume_data` (`score.py`), which already decides adequacy and only requires `any()` of the core sections.

## Before -> after (resume with no awards)

```
BEFORE: basics work education skills projects -> ERROR abort (all lost), returns None
AFTER : basics work education skills projects -> WARNING "No 'awards' section (optional). Skipping.", returns JSONResume
```

An empty `basics` still aborts (no candidate identity = not a resume).

## Design notes

- Kept the truthiness check (`if section_data:`). An empty `{}` genuinely means "no data extracted"; switching to `is not None` would treat `{}` as success and silently accept empty **required** sections — re-introducing the wrong-score failure #202 describes.
- `required_sections = {"basics"}` is grounded in the codebase, not arbitrary: `score.py` derives `candidate_name` from `basics.name`; `Basics.name` is the only non-`Optional` field in `models.py`; and `basics` is the JSON Resume spec's sole required section. It's also stricter than `is_valid_resume_data` (which accepts any-of-5), so it's a conservative floor.