### PR TITLE
feat: detect external open-source contributions via merged PRs

### DIFF
--- a/github.py
+++ b/github.py
@@ -307,6 +307,85 @@ def fetch_all_github_repos(github_url: str, max_repos: int = 100) -> List[Dict]:
         return []
 
 
+def aggregate_external_repos(items: List[Dict], username: str) -> Dict[str, Dict]:
+    repos: Dict[str, Dict] = {}
+    for item in items:
+        repo_api_url = item.get("repository_url", "")
+        if not repo_api_url:
+            continue
+        full_name = repo_api_url.replace("https://api.github.com/repos/", "")
+        owner = full_name.split("/", 1)[0] if "/" in full_name else ""
+        # Only count contributions to other people's repositories
+        if not owner or owner.lower() == username.lower():
+            continue
+        entry = repos.setdefault(
+            full_name, {"api_url": repo_api_url, "merged_pr_count": 0}
+        )
+        entry["merged_pr_count"] += 1
+    return repos
+
+
+def fetch_external_contributions(
+    username: Optional[str], max_repos: int = 10
+) -> List[Dict]:
+    if not username:
+        return []
+
+    try:
+        api_url = "https://api.github.com/search/issues"
+        params = {
+            "q": f"author:{username} type:pr is:merged",
+            "per_page": 100,
+            "sort": "created",
+            "order": "desc",
+        }
+
+        status_code, data = _fetch_github_api(api_url, params=params)
+        if status_code != 200 or not isinstance(data, dict):
+            return []
+
+        repos = aggregate_external_repos(data.get("items", []) or [], username)
+        if not repos:
+            return []
+
+        top_repos = sorted(
+            repos.items(), key=lambda kv: kv[1]["merged_pr_count"], reverse=True
+        )[:max_repos]
+
+        contributions = []
+        for full_name, info in top_repos:
+            stars = 0
+            language = None
+            description = None
+            html_url = f"https://github.com/{full_name}"
+
+            repo_status, repo_data = _fetch_github_api(info["api_url"])
+            if repo_status == 200 and isinstance(repo_data, dict):
+                stars = repo_data.get("stargazers_count", 0)
+                language = repo_data.get("language")
+                description = repo_data.get("description")
+                html_url = repo_data.get("html_url", html_url)
+
+            contributions.append(
+                {
+                    "repo": full_name,
+                    "owner": full_name.split("/", 1)[0],
+                    "html_url": html_url,
+                    "merged_pr_count": info["merged_pr_count"],
+                    "stars": stars,
+                    "language": language,
+                    "description": description,
+                }
+            )
+
+        contributions.sort(key=lambda c: c["stars"], reverse=True)
+        return contributions
+
+    except Exception as e:
+        logger.error(f"Error fetching external contributions for {username}: {e}")
+        return []
+
+
 def generate_profile_json(profile: GitHubProfile) -> Dict:
     if not profile:
         return {}
@@ -472,10 +551,24 @@ def fetch_and_display_github_info(github_url: str) -> Dict:
     profile_json = generate_profile_json(github_profile)
     projects_json = generate_projects_json(projects)
 
+    print(
+        "🔗 Detecting external open-source contributions (merged PRs to repos the user does not own)..."
+    )
+    username = extract_github_username(github_url)
+    external_contributions = fetch_external_contributions(username)
+    if external_contributions:
+        total_prs = sum(c["merged_pr_count"] for c in external_contributions)
+        print(
+            f"✅ Found {total_prs} merged PR(s) across {len(external_contributions)} external repositor(ies)"
+        )
+    else:
+        print("ℹ️  No external open-source contributions detected")
+
     result = {
         "profile": profile_json,
         "projects": projects_json,
         "total_projects": len(projects_json),
+        "open_source_contributions": external_contributions,
     }
 
     return result

--- a/prompts/templates/resume_evaluation_criteria.jinja
+++ b/prompts/templates/resume_evaluation_criteria.jinja
@@ -57,7 +57,8 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 **CRITICAL RULES:**
 - Having personal GitHub repositories does NOT constitute open source contribution
 - True open source contribution means contributing to OTHER people's projects
-- When GitHub data shows all projects are 'self_project' type, open source score MUST be 10 points or less
+- When GitHub data shows all projects are 'self_project' type AND there is NO "Verified External Open-Source Contributions" section, open source score MUST be 10 points or less
+- EXCEPTION: If a "Verified External Open-Source Contributions" section is present (confirmed merged PRs to repositories the candidate does NOT own), treat those as genuine open source contributions and score this category on their significance — the stars of the contributed-to projects and the number of merged PRs — even when all of the candidate's OWN listed repos are 'self_project'
 
 ### Self Projects (0-30 points)
 **HIGH SCORES (20-30 points):**
@@ -137,8 +138,8 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 - -1 to -2 points for each project with broken or inactive links
 
 **CRITICAL ENFORCEMENT:**
-- When GitHub data shows all projects are 'self_project' type, apply 3-5 point deductions for lack of true open source contributions
-- For candidates with only personal GitHub repositories, open source score should NEVER exceed 10 points
+- When GitHub data shows all projects are 'self_project' type AND no "Verified External Open-Source Contributions" section is present, apply 3-5 point deductions for lack of true open source contributions
+- For candidates with only personal GitHub repositories and no verified external contributions, open source score should NEVER exceed 10 points
 - For candidates with only tutorial-based projects, self_projects score should NEVER exceed 15 points
 
 ## CRITICAL REQUIREMENTS

--- a/transform.py
+++ b/transform.py
@@ -918,6 +918,31 @@ def convert_github_data_to_text(github_data: dict) -> str:
                 github_text += f"   Language: {details.get('language', 'N/A')}\n"
             github_text += "\n"
 
+    contributions = github_data.get("open_source_contributions") or []
+    if contributions:
+        total_prs = sum(c.get("merged_pr_count", 0) for c in contributions)
+        github_text += (
+            f"\nVerified External Open-Source Contributions "
+            f"({total_prs} merged PR(s) authored in {len(contributions)} "
+            f"repositories the candidate does NOT own):\n"
+        )
+        github_text += (
+            "These are REAL open-source contributions to OTHER people's projects "
+            "(confirmed merged PRs), NOT self_projects. Weigh them for the Open "
+            "Source score based on the projects' significance (stars) and number "
+            "of merged PRs.\n"
+        )
+        for i, contrib in enumerate(contributions[:10], 1):
+            github_text += f"{i}. {contrib.get('repo', 'N/A')}\n"
+            github_text += (
+                f"   Merged PRs by candidate: {contrib.get('merged_pr_count', 'N/A')}\n"
+            )
+            github_text += f"   Stars: {contrib.get('stars', 'N/A')}\n"
+            github_text += f"   Language: {contrib.get('language', 'N/A')}\n"
+            if contrib.get("description"):
+                github_text += f"   Description: {contrib.get('description')}\n"
+            github_text += "\n"
+
     return github_text
 
 


### PR DESCRIPTION
Closes #228

## Problem

The GitHub enrichment stage (`fetch_all_github_repos` in `github.py`) only inspects a candidate's **own** repositories and classifies each as `open_source` vs `self_project` by contributor count. A merged PR to an external project (e.g. `cloud-custodian/cloud-custodian`) is invisible, so the Open Source score leans entirely on free-text resume claims — and the rubric's hard rule (*all `self_project` → ≤10*) can wrongly cap genuine contributors who only have personal repos under their own account.

## Change

- **`github.py`** — new `fetch_external_contributions()` queries the GitHub Search API (`author:<user> type:pr is:merged`), filters to repos the user does **not** own, aggregates merged-PR counts per repo (via the pure helper `aggregate_external_repos`), and enriches the top repos with star counts. Wired into `fetch_and_display_github_info()` as `github_data["open_source_contributions"]`.
- **`transform.py`** — `convert_github_data_to_text()` renders a "Verified External Open-Source Contributions" block (repo, merged-PR count, stars, language) into the `=== GITHUB DATA ===` text.
- **`resume_evaluation_criteria.jinja`** — adds an exception so verified external contributions are scored on significance (stars + merged-PR count) rather than capped at 10.

## Prompt change (before / after)

**Before:**
> When GitHub data shows all projects are 'self_project' type, open source score MUST be 10 points or less

**After:**
> When GitHub data shows all projects are 'self_project' type **AND there is NO "Verified External Open-Source Contributions" section**, open source score MUST be 10 points or less
> **EXCEPTION:** If a "Verified External Open-Source Contributions" section is present (confirmed merged PRs to repositories the candidate does NOT own), treat those as genuine open source contributions and score this category on their significance...

## Testing

- Pure-helper unit behavior: excludes self-owned repos, skips empty `repository_url`, counts merged PRs.
- GitHub enrichment on a known username (`strixthekiet`): correctly returns `cloud-custodian/cloud-custodian` (6,013 stars, 1 merged PR).
- `black --check` passes on changed files.
