### PR TITLE
fix: do not abort extraction when an optional section is empty

### DIFF
--- a/pdf.py
+++ b/pdf.py
@@ -106,6 +106,9 @@ class PDFHandler:
             response = self.provider.chat(**chat_params, **kwargs)
 
             response_text = response["message"]["content"]
+            logger.debug(
+                f"📥 Raw {section_name} response ({len(response_text) if response_text else 0} chars)"
+            )
 
             try:
                 response_text = extract_json_from_response(response_text)
@@ -117,6 +120,16 @@ class PDFHandler:
                 logger.debug(f"✅ Successfully extracted {section_name} section")
 
                 transformed_data = transform_parsed_data(parsed_data)
+
+                if not transformed_data:
+                    # Valid JSON but an empty object. Surface the raw response so an
+                    # empty section is distinguishable from a parse/extraction
+                    # failure (which is logged in the JSONDecodeError branch below).
+                    logger.warning(
+                        f"⚠️ {section_name} section returned an empty object. "
+                        f"Raw response: {response_text!r}"
+                    )
+
                 end_time = time.time()
                 total_time = end_time - start_time
                 logger.debug(
@@ -289,14 +302,21 @@ class PDFHandler:
         for section_name in sections:
             section_data = self._extract_section_data(text_content, section_name)
 
-            if section_data:
-                complete_resume.update(section_data)
-                logger.debug(f"✅ Successfully extracted {section_name} section")
-            else:
+            if section_data is None:
+                # Real extraction/parse failure: abort to avoid partial/invalid data.
                 logger.error(
                     f"⚠️ Failed to extract {section_name} section. Aborting extraction to prevent partial/invalid resume data."
                 )
                 return None
+            elif not section_data:
+                # Valid response but an empty object (e.g. a CV with no skills).
+                # Leave the section unset and continue instead of aborting the run.
+                logger.warning(
+                    f"ℹ️ {section_name} section is empty; continuing with it unset."
+                )
+            else:
+                complete_resume.update(section_data)
+                logger.debug(f"✅ Successfully extracted {section_name} section")
 
         try:
             if complete_resume.get("basics") and isinstance(


### PR DESCRIPTION
## Problem

When a section's LLM call returns valid JSON that is an empty object `{}` (no parse error raised), `PDFHandler._extract_all_sections_separately` rejected it via a falsy `if section_data:` check and aborted the **entire** run with only:

```
⚠️ Failed to extract skills section. Aborting extraction to prevent partial/invalid resume data.
```

The empty-`{}` path never reaches the `JSONDecodeError`/exception branches in `_call_llm_for_section` that log the raw response, so an empty section was indistinguishable from a real extraction/parse failure, and the raw model response was never surfaced. At the default INFO level the per-section debug breadcrumbs are hidden too, leaving only the single abort line.

## Changes (`pdf.py`)

- **`_call_llm_for_section`**: log the raw response length, and when a section parses to an empty object, emit a `WARNING` including the raw response — so the cause is diagnosable at the default INFO level and "returned empty" is distinguished from "extraction failed".
- **`_extract_all_sections_separately`**: distinguish an empty optional section from a real failure. Abort only when `section_data is None`; when it is an empty object, warn and continue with that section left unset rather than aborting the whole resume.

## Behavior

Before — an empty skills `{}` aborts the whole run:
```
ERROR - ⚠️ Failed to extract skills section. Aborting extraction...
(no raw response, run aborts)
```

After:
```
WARNING - ⚠️ skills section returned an empty object. Raw response: '{}'
WARNING - ℹ️ skills section is empty; continuing with it unset.
(run continues; resume built with skills unset)
```
A genuine failure (`None`) still aborts as before.

## Testing

Mocked `_extract_section_data` to exercise both paths against `_extract_all_sections_separately`:
- skills returns `{}` (empty) -> run continues, `JSONResume` built with skills unset.
- skills returns `None` (failure) -> run aborts (returns `None`), preserving existing safety.

`black pdf.py` reports no formatting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
