### PR TITLE
feat: add OpenAI provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,15 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "openai"
 LLM_PROVIDER=ollama
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For OpenAI: "gpt-4o-mini", "gpt-4o", etc.
 DEFAULT_MODEL=gemma3:4b
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# OpenAI API Key (required if using OpenAI provider)
+OPENAI_API_KEY=your_openai_api_key_here

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a lo
   - **Ollama** for local models
     Install from the [official site](https://ollama.com/), then run `ollama serve`.
   - **Google Gemini** if you have an API key, get it from [here](https://aistudio.google.com/api-keys).
+  - **OpenAI** if you have an API key, get it from [here](https://platform.openai.com/api-keys).
 
 ### Quick setup with pip
 
@@ -138,10 +139,11 @@ $ cp .env.example .env
 
 | Variable         | Values                                      | Description                                                            |
 | ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
-| `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
-| `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
+| `LLM_PROVIDER`   | `ollama`, `gemini`, or `openai`                       | Chooses provider. Defaults to Ollama.                                  |
+| `DEFAULT_MODEL`  | for example `gemma3:4b`, `gemini-2.5-pro`, or `gpt-4o-mini` | Model name passed to the provider.                                     |
+| `GEMINI_API_KEY` | string                                                | Required when using Gemini models.                                     |
+| `OPENAI_API_KEY` | string                                                | Required when using OpenAI models.                                     |
+| `GITHUB_TOKEN`   | optional                                              | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
 
@@ -265,6 +267,13 @@ What happens:
 - Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
+
+### OpenAI
+
+- Set `LLM_PROVIDER=openai`
+- Set `DEFAULT_MODEL` to a supported OpenAI model, for example `gpt-4o-mini`
+- Provide `OPENAI_API_KEY`
+- The wrapper in `models.OpenAIProvider` adapts Responses API output to a unified format
 
 ---
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,8 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import ModelProvider, OllamaProvider, GeminiProvider, OpenAIProvider
+from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY, OPENAI_API_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,12 @@ def initialize_llm_provider(model_name: str) -> Any:
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.OPENAI:
+        if not OPENAI_API_KEY:
+            logger.warning("⚠️ OpenAI API key not found. Falling back to Ollama.")
+        else:
+            logger.info(f"🔄 Using OpenAI API provider with model {model_name}")
+            provider = OpenAIProvider(api_key=OPENAI_API_KEY)
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
     return provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    OPENAI = "openai"
 
 
 @runtime_checkable
@@ -351,3 +352,57 @@ class GeminiProvider:
 
         # Convert Gemini response to Ollama-like format for compatibility
         return {"message": {"role": "assistant", "content": response.text}}
+
+
+class OpenAIProvider:
+    """OpenAI LLM provider implementation."""
+
+    def __init__(self, api_key: str):
+        from openai import OpenAI
+
+        self.client = OpenAI(api_key=api_key)
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Send a chat request to OpenAI and return an Ollama-like response."""
+        instructions = "\n\n".join(
+            msg["content"] for msg in messages if msg["role"] == "system"
+        )
+        input_messages = [
+            {"role": msg["role"], "content": msg["content"]}
+            for msg in messages
+            if msg["role"] != "system"
+        ]
+
+        request_params: Dict[str, Any] = {
+            "model": model,
+            "input": input_messages,
+        }
+
+        if instructions:
+            request_params["instructions"] = instructions
+
+        if options:
+            if "temperature" in options:
+                request_params["temperature"] = options["temperature"]
+            if "top_p" in options:
+                request_params["top_p"] = options["top_p"]
+
+        if "format" in kwargs:
+            request_params["text"] = {
+                "format": {
+                    "type": "json_schema",
+                    "name": "structured_response",
+                    "schema": kwargs["format"],
+                    "strict": False,
+                }
+            }
+
+        response = self.client.responses.create(**request_params)
+
+        return {"message": {"role": "assistant", "content": response.output_text}}

--- a/prompt.py
+++ b/prompt.py
@@ -41,6 +41,9 @@ MODEL_PARAMETERS = {
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # OpenAI models
+    "gpt-4o-mini": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-4o": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -61,7 +64,11 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
+    # OpenAI models
+    "gpt-4o-mini": ModelProvider.OPENAI,
+    "gpt-4o": ModelProvider.OPENAI,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Jinja2==3.1.6
 google-generativeai==0.4.0
 python-dotenv==1.0.1
 black==25.9.0
+openai==2.14.0


### PR DESCRIPTION
Adds OpenAI as a supported LLM provider alongside Ollama and Gemini.

Changes:
- Add OpenAIProvider using the OpenAI Responses API
- Add OPENAI_API_KEY environment variable
- Add gpt-4o-mini and gpt-4o model mappings
- Update requirements and documentation

Validation:
- Ran Python syntax checks with py_compile across project modules
- Tested OpenAI provider locally with gpt-4o-mini on a resume scoring run