### PR TITLE
Add OpenRouter provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,18 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
-LLM_PROVIDER=ollama
+# Options: "ollama", "gemini", or "openrouter"
+LLM_PROVIDER=openrouter
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
-DEFAULT_MODEL=gemma3:4b
+# For OpenRouter: "openai/gpt-4o-mini", "google/gemini-2.5-flash", etc.
+DEFAULT_MODEL=openai/gpt-4o-mini
 
 # Google Gemini API Key (required if using Gemini provider)
-GEMINI_API_KEY=your_gemini_api_key_here
+GEMINI_API_KEY=
+
+# OpenRouter API Key (required if using OpenRouter provider)
+OPENROUTER_API_KEY=
+
+# GitHub token (optional, increases API rate limits)
+GITHUB_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -159,8 +159,10 @@ activemq-data/
 
 # Environments
 .env
+.env.*
+!.env.example
 .envrc
-.venv
+.venv/
 env/
 venv/
 ENV/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Overview
 
-Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use Google Gemini.
+Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use OpenRouter or Google Gemini.
 
 ---
 
@@ -85,10 +85,11 @@ Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a lo
 
   The repository pins `.python-version` to 3.11.13.
 
-- **One LLM backend** (either of them)
+- **One LLM backend**
 
   - **Ollama** for local models
     Install from the [official site](https://ollama.com/), then run `ollama serve`.
+  - **OpenRouter** if you have an API key, get it from [OpenRouter](https://openrouter.ai/keys).
   - **Google Gemini** if you have an API key, get it from [here](https://aistudio.google.com/api-keys).
 
 ### Quick setup with pip
@@ -136,12 +137,13 @@ $ cp .env.example .env
 
 **Environment variables**
 
-| Variable         | Values                                      | Description                                                            |
-| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
-| `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
-| `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
+| Variable             | Values                                                         | Description                                                            |
+| -------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `LLM_PROVIDER`       | `ollama`, `gemini`, or `openrouter`                            | Chooses provider. Defaults to Ollama in code.                          |
+| `DEFAULT_MODEL`      | for example `gemma3:4b`, `gemini-2.5-pro`, or `openai/gpt-4o-mini` | Model name passed to the provider.                                  |
+| `GEMINI_API_KEY`     | string                                                         | Required when `LLM_PROVIDER=gemini`.                                   |
+| `OPENROUTER_API_KEY` | string                                                         | Required when `LLM_PROVIDER=openrouter`.                               |
+| `GITHUB_TOKEN`       | optional                                                       | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
 
@@ -265,6 +267,13 @@ What happens:
 - Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
+
+### OpenRouter
+
+- Set `LLM_PROVIDER=openrouter`
+- Set `DEFAULT_MODEL` to an OpenRouter model slug, for example `openai/gpt-4o-mini`
+- Provide `OPENROUTER_API_KEY`
+- The wrapper in `models.OpenRouterProvider` calls OpenRouter's OpenAI-compatible chat completions endpoint and adapts responses to the unified format
 
 ---
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,8 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import ModelProvider, OllamaProvider, GeminiProvider, OpenRouterProvider
+from prompt import MODEL_PROVIDER_MAPPING, PROVIDER, GEMINI_API_KEY, OPENROUTER_API_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -45,18 +45,30 @@ def initialize_llm_provider(model_name: str) -> Any:
         model_name: The name of the model to use
 
     Returns:
-        An initialized LLM provider (either OllamaProvider or GeminiProvider)
+        An initialized LLM provider
     """
-    # Default to Ollama provider
-    provider = OllamaProvider()
-    # If using Gemini and API key is available, use Gemini provider
-    model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
+    configured_provider = (
+        ModelProvider(PROVIDER)
+        if PROVIDER in [provider.value for provider in ModelProvider]
+        else ModelProvider.OLLAMA
+    )
+    model_provider = (
+        configured_provider
+        if configured_provider != ModelProvider.OLLAMA
+        else MODEL_PROVIDER_MAPPING.get(model_name, configured_provider)
+    )
+
     if model_provider == ModelProvider.GEMINI:
         if not GEMINI_API_KEY:
             logger.warning("⚠️ Gemini API key not found. Falling back to Ollama.")
+            provider = OllamaProvider()
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.OPENROUTER:
+        logger.info(f"🔄 Using OpenRouter API provider with model {model_name}")
+        provider = OpenRouterProvider(api_key=OPENROUTER_API_KEY)
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
+        provider = OllamaProvider()
     return provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    OPENROUTER = "openrouter"
 
 
 @runtime_checkable
@@ -19,7 +20,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -281,7 +282,7 @@ class OllamaProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -324,7 +325,7 @@ class GeminiProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Google Gemini API."""
         import re
@@ -375,7 +376,7 @@ class GeminiProvider:
                 api_hint = float(match.group(1)) if match else None
 
                 # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
-                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
 
                 # Prefer the API hint when it is shorter than our computed delay
                 delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay
@@ -389,3 +390,122 @@ class GeminiProvider:
                     f"Retrying in {sleep_time}s..."
                 )
                 time.sleep(sleep_time)
+
+
+class OpenRouterProvider:
+    """OpenRouter API provider implementation."""
+
+    API_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+    def __init__(self, api_key: str = ""):
+        self.api_key = api_key
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Send a chat request to OpenRouter."""
+        import requests
+
+        if not self.api_key:
+            raise ValueError(
+                "OPENROUTER_API_KEY is required when LLM_PROVIDER=openrouter"
+            )
+
+        openrouter_options = options.copy() if options else {}
+        stream = bool(openrouter_options.pop("stream", kwargs.pop("stream", False)))
+
+        payload = {
+            "model": model,
+            "messages": self._prepare_messages(messages, kwargs.get("format")),
+            "stream": stream,
+        }
+
+        for option in ("temperature", "top_p"):
+            if option in openrouter_options:
+                payload[option] = openrouter_options[option]
+
+        schema = kwargs.get("format")
+        if schema:
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "hiring_agent_response",
+                    "strict": True,
+                    "schema": schema,
+                },
+            }
+            payload["structured_outputs"] = True
+
+        try:
+            return self._post(payload)
+        except requests.HTTPError as error:
+            if not schema or not self._is_response_format_error(error):
+                raise
+
+            fallback_payload = payload.copy()
+            fallback_payload["response_format"] = {"type": "json_object"}
+            fallback_payload.pop("structured_outputs", None)
+            return self._post(fallback_payload)
+
+    def _prepare_messages(
+        self, messages: List[Dict[str, str]], schema: Optional[Dict[str, Any]]
+    ) -> List[Dict[str, str]]:
+        if not schema:
+            return messages
+
+        schema_instruction = (
+            "Return only valid JSON matching the requested schema. "
+            "Do not wrap the response in markdown."
+        )
+
+        prepared_messages = [message.copy() for message in messages]
+        if prepared_messages and prepared_messages[0].get("role") == "system":
+            prepared_messages[0]["content"] = (
+                prepared_messages[0].get("content", "") + "\n\n" + schema_instruction
+            )
+        else:
+            prepared_messages.insert(
+                0, {"role": "system", "content": schema_instruction}
+            )
+        return prepared_messages
+
+    def _post(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        import requests
+
+        response = requests.post(
+            self.API_URL,
+            json=payload,
+            timeout=120,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "X-OpenRouter-Title": "Hiring Agent",
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+        choices = data.get("choices") or []
+        if not choices or "message" not in choices[0]:
+            raise ValueError("OpenRouter response did not include a chat message")
+
+        content = choices[0]["message"].get("content", "")
+        return {"message": {"role": "assistant", "content": content}}
+
+    def _is_response_format_error(self, error: Exception) -> bool:
+        response = getattr(error, "response", None)
+        if response is None or response.status_code not in (400, 422):
+            return False
+        try:
+            body = response.text.lower()
+        except Exception:
+            body = ""
+        return (
+            "response_format" in body
+            or "structured" in body
+            or "invalid_json_schema" in body
+            or "schema" in body
+        )

--- a/prompt.py
+++ b/prompt.py
@@ -41,6 +41,8 @@ MODEL_PARAMETERS = {
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # OpenRouter models
+    "openai/gpt-4o-mini": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -61,7 +63,10 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
+    # OpenRouter models
+    "openai/gpt-4o-mini": ModelProvider.OPENROUTER,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")


### PR DESCRIPTION
## Summary
- add OpenRouter as a third LLM provider while keeping Ollama and Gemini support
- document OpenRouter configuration and blank API key placeholders
- ignore local env/venv files while preserving `.env.example`
- fall back from strict JSON schema response_format to JSON object mode for providers that reject Pydantic schemas

## Validation
- `python -m py_compile llm_utils.py models.py prompt.py`
- `python -m black --check llm_utils.py models.py prompt.py`
- Ran `score.py` against a real resume with `LLM_PROVIDER=openrouter`, `DEFAULT_MODEL=openai/gpt-5.5`, and GitHub enrichment enabled; generated terminal report, CSV row, and GitHub cache successfully.