### PR TITLE
fix: validate LLM bonus claims and reject hallucinated GitHub projects

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -22,6 +22,15 @@ logger = logging.getLogger(__name__)
 
 
 class ResumeEvaluator:
+    # High-value bonus claims that smaller models commonly fabricate. Maps a
+    # human-readable claim to the keywords that signal it; the same keywords must
+    # appear in the candidate's resume/GitHub text for the claim to be verifiable.
+    VERIFIABLE_BONUS_CLAIMS = {
+        "Google Summer of Code (GSoC)": ["gsoc", "google summer of code"],
+        "Girl Script Summer of Code": ["girl script", "girlscript", "gssoc"],
+        "Startup Founder/Co-founder": ["founder", "co-founder", "cofounder"],
+    }
+
     def __init__(self, model_name: str = DEFAULT_MODEL, model_params: dict = None):
         if not model_name:
             raise ValueError("Model name cannot be empty")
@@ -84,8 +93,51 @@ class ResumeEvaluator:
             evaluation_dict = json.loads(response_text)
             evaluation_data = EvaluationData(**evaluation_dict)
 
+            evaluation_data = self._validate_bonus_points(
+                evaluation_data, self._last_resume_text
+            )
+
             return evaluation_data
 
         except Exception as e:
             logger.error(f"Error evaluating resume: {str(e)}")
             raise
+
+    def _validate_bonus_points(
+        self, evaluation_data: EvaluationData, input_text: str
+    ) -> EvaluationData:
+        """Zero out bonus points if any high-value claim cannot be verified.
+
+        The LLM (especially smaller models) fabricates bonus claims such as GSoC
+        or startup-founder experience that do not appear in the resume or GitHub
+        data. A claim is unverifiable when its keyword shows up in the LLM's
+        breakdown but nowhere in the input text. If any such claim is found, the
+        bonus total is zeroed to prevent score inflation.
+        """
+        bonus = evaluation_data.bonus_points
+        if not bonus or bonus.total <= 0:
+            return evaluation_data
+
+        breakdown_lower = (bonus.breakdown or "").lower()
+        text_lower = (input_text or "").lower()
+
+        unverifiable = [
+            claim
+            for claim, keywords in self.VERIFIABLE_BONUS_CLAIMS.items()
+            if any(kw in breakdown_lower for kw in keywords)
+            and not any(kw in text_lower for kw in keywords)
+        ]
+
+        if unverifiable:
+            logger.warning(
+                "⚠️ Zeroing bonus points: claim(s) not found in resume/GitHub data: "
+                + ", ".join(unverifiable)
+            )
+            bonus.breakdown = (
+                "Bonus points zeroed: unverifiable claim(s) not present in "
+                f"resume/GitHub data: {', '.join(unverifiable)}. "
+                f"Original breakdown: {bonus.breakdown}"
+            )
+            bonus.total = 0
+
+        return evaluation_data

--- a/github.py
+++ b/github.py
@@ -398,14 +398,26 @@ def generate_projects_json(projects: List[Dict]) -> List[Dict]:
 
             selected_projects = json.loads(response_text)
 
+            # Map of real repo names -> authoritative project data. The LLM can
+            # hallucinate repos the candidate has no association with (e.g.
+            # "TensorFlow", "Kubernetes"), so only names present here are accepted,
+            # and we use this data rather than the LLM's (possibly fabricated) copy.
+            valid_by_name = {p["name"]: p for p in projects_data if p.get("name")}
+
             unique_projects = []
             seen_names = set()
 
             for project in selected_projects:
                 project_name = project.get("name", "")
-                if project_name and project_name not in seen_names:
-                    unique_projects.append(project)
-                    seen_names.add(project_name)
+                if not project_name or project_name in seen_names:
+                    continue
+                if project_name not in valid_by_name:
+                    print(
+                        f"⚠️ Dropping hallucinated project not in candidate's repos: {project_name}"
+                    )
+                    continue
+                unique_projects.append(valid_by_name[project_name])
+                seen_names.add(project_name)
 
             if len(unique_projects) < 7:
                 print(

--- a/prompts/templates/resume_evaluation_criteria.jinja
+++ b/prompts/templates/resume_evaluation_criteria.jinja
@@ -114,6 +114,13 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 - Projects demonstrating advanced algorithms or data structures
 
 ## BONUS POINTS (Maximum total: 20 points)
+**CRITICAL — VERIFY BEFORE AWARDING**: Award a bonus ONLY when the achievement is
+explicitly stated in the resume text or GitHub data above. The list below is a
+scoring rubric, NOT a checklist of things to assume are present. If an item does
+not literally appear in the input, award 0 for it and do NOT mention it in the
+breakdown. Never infer GSoC, Girl Script Summer of Code, or founder experience
+from the presence of these examples — they must be quoted from the actual input.
+
 - +5 points for Google Summer of Code (GSoC) participation
 - +3 points for Girl Script Summer of Code participation
 - +3-5 points for startup founder/co-founder experience
@@ -121,6 +128,9 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 - +2 points for portfolio website (GitHub URL in basics.url)
 - +1 point for LinkedIn profile
 - +1-3 points for high-quality technical blogs (if blog data provided)
+
+For every bonus awarded, the breakdown MUST cite the specific text from the
+resume/GitHub data that justifies it. If you cannot cite it, do not award it.
 
 **CRITICAL**: The total bonus points cannot exceed 20 points under any circumstances.
 


### PR DESCRIPTION
Refs #240.

## Problem

The pipeline trusted LLM output without verification in two places, which smaller models (e.g. `gemma3:4b`) exploited to inflate scores by 10-32 points:

1. **Bonus points** — `evaluator.py` passed the LLM JSON straight into `EvaluationData()`. The model fabricated claims like "GSoC", "Girl Script Summer of Code", and "Startup Founder/Co-founder" that appear nowhere in the resume or GitHub data. The hallucination was *seeded by the prompt itself*: the bonus rubric in `resume_evaluation_criteria.jinja` lists those exact items as examples, so the model treats them as present.
2. **Project selection** — `github.py`'s `generate_projects_json` accepted LLM-selected repo *names* without checking they belong to the candidate, so it could return "TensorFlow, Kubernetes, React" for someone with 2 personal repos.

## Changes

- **`evaluator.py`** — add `_validate_bonus_points`, a post-LLM step. A `VERIFIABLE_BONUS_CLAIMS` map links high-value claims (GSoC, Girl Script, founder) to their keywords. If a claim keyword appears in the LLM breakdown but nowhere in the resume/GitHub text, the bonus total is **zeroed** and the breakdown annotated. (Behavior chosen: zero-out-if-any-unverifiable.)
- **`github.py`** — `generate_projects_json` now builds a map of the candidate's real repo names and only accepts selected projects present in it, using that authoritative data rather than the LLM's copy. Hallucinated repos are dropped (logged) and the existing top-up-to-7 logic backfills from real repos.
- **`resume_evaluation_criteria.jinja`** — harden the bonus section: award a bonus only when explicitly present in the input, cite the supporting text, and never infer the rubric examples as defaults.

## Behavior

Before:
```
open_source evidence: "Contributions to TensorFlow, Kubernetes, React, ..."
bonus_points: {total: 10, breakdown: "GSoC (5), Girl Script (3), Founder (2)"}
```
After (claims absent from input):
```
⚠️ Dropping hallucinated project not in candidate's repos: TensorFlow
⚠️ Zeroing bonus points: claim(s) not found in resume/GitHub data: Google Summer of Code (GSoC), ...
bonus_points: {total: 0, breakdown: "Bonus points zeroed: unverifiable claim(s) ... Original breakdown: ..."}
```

## Testing

- `_validate_bonus_points`: GSoC/founder claimed but absent -> total zeroed; GSoC claimed and present in text -> kept; benign portfolio/LinkedIn bonuses -> untouched.
- `generate_projects_json` (mocked provider returning a real + a hallucinated repo): hallucinated repo dropped, real repo kept, list backfilled from real repos.
- `black --check evaluator.py github.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
