### PR TITLE
fix: read GitHub stats from profile dict for CSV export (fixes #216)

### DIFF
--- a/transform.py
+++ b/transform.py
@@ -656,12 +656,14 @@ def transform_evaluation_response(
         csv_row["total_projects"] = 0
 
     # Extract GitHub data
+    # Extract GitHub data
     if github_data:
-        csv_row["github_repos"] = github_data.get("public_repos", 0)
-        csv_row["github_followers"] = github_data.get("followers", 0)
-        csv_row["github_following"] = github_data.get("following", 0)
-        csv_row["github_created_at"] = github_data.get("created_at", "")
-        csv_row["github_bio"] = github_data.get("bio", "")
+        profile = github_data.get("profile", {})
+        csv_row["github_repos"] = profile.get("public_repos", 0)
+        csv_row["github_followers"] = profile.get("followers", 0)
+        csv_row["github_following"] = profile.get("following", 0)
+        csv_row["github_created_at"] = profile.get("created_at", "")
+        csv_row["github_bio"] = profile.get("bio", "")
     else:
         csv_row["github_repos"] = 0
         csv_row["github_followers"] = 0


### PR DESCRIPTION
Fixes #216

## Problem
`transform_evaluation_response` was reading GitHub stats directly off the
top-level `github_data` dict, but `fetch_and_display_github_info` returns
them nested under `github_data["profile"]`. This caused `github_repos`,
`github_followers`, `github_following`, `github_created_at`, and
`github_bio` to always be `0`/empty in the exported CSV.

## Fix
Extract the nested `profile` dict first, then read fields from it —
consistent with how `convert_github_data_to_text` already accesses the
same data in the same file.

## Changes
- `transform.py`: one extra line `profile = github_data.get("profile", {})`
  and five `.get()` calls now read from `profile` instead of `github_data`