### PR TITLE
fix: extract clickable URL annotations from PDF for accurate profile detection

### DIFF
--- a/pdf.py
+++ b/pdf.py
@@ -55,6 +55,34 @@ class PDFHandler:
                     doc,
                     pages=pages,
                 )
+
+                # Collect HTTP/HTTPS URIs from PDF link annotations.
+                # Many resumes embed clickable hyperlinks (e.g. display text "GitHub"
+                # pointing to https://github.com/user) that to_markdown() drops because
+                # they are annotations, not visible text. Appending them explicitly
+                # ensures the LLM can extract accurate profile URLs.
+                seen_uris: set[str] = set()
+                clickable_urls: list[str] = []
+                for page in doc:
+                    for link in page.get_links():
+                        uri = link.get("uri", "")
+                        if (
+                            uri.startswith(("http://", "https://"))
+                            and uri not in seen_uris
+                        ):
+                            seen_uris.add(uri)
+                            clickable_urls.append(uri)
+
+                if clickable_urls:
+                    url_section = (
+                        "\n\n=== CLICKABLE LINKS IN RESUME ===\n"
+                        + "\n".join(clickable_urls)
+                    )
+                    resume_text = (resume_text or "") + url_section
+                    logger.debug(
+                        f"Appended {len(clickable_urls)} clickable URL(s) from PDF annotations"
+                    )
+
                 logger.debug(
                     f"Extracted text from PDF: {len(resume_text) if resume_text else 0} characters"
                 )


### PR DESCRIPTION
## Problem
`PDFHandler` uses `to_markdown()` (PyMuPDF) to extract resume text. This only captures *visible* text — it silently drops PDF link annotations. Many resumes embed hyperlinks where the display text is `GitHub` or `LinkedIn` but the actual URL lives as a hidden annotation. The LLM never sees it, so the `profiles` array in the extracted JSON comes back empty or wrong.
## Fix
In `extract_text_from_pdf()`, reuse the already-open `doc` to call `page.get_links()` on each page. Collect all unique `http://` / `https://` URIs and append them as an explicit block:
=== CLICKABLE LINKS IN RESUME === https://github.com/username https://linkedin.com/in/username


This satisfies the existing `basics.jinja` constraint ("ONLY extract URLs that are EXPLICITLY present in the resume markdown") with no prompt changes needed.
## Details
- No extra `pymupdf.open()` call — reuses the already-open `doc`
- Deduplicates across pages via a `seen_uris` set
- Filters to HTTP/HTTPS only (ignores `mailto:`, internal `#anchor` links)
- `pymupdf_rag.py` is untouched
Fixes #152