### PR TITLE
Add OpenAI provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,15 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "openai"
 LLM_PROVIDER=ollama
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For OpenAI: "gpt-5.5", "gpt-4.1", "gpt-4o-mini", etc.
 DEFAULT_MODEL=gemma3:4b
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# OpenAI API Key (required if using OpenAI provider)
+OPENAI_API_KEY=your_openai_api_key_here

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ Thanks for your interest in improving this project. Contributions are welcome, i
 
   * One run with Ollama using the default local model.
   * One run with Gemini if you have an API key.
+  * One run with OpenAI if you have an API key.
 * Add or adjust small smoke tests that exercise each stage with minimal inputs:
 
   * PDF to Markdown

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Overview
 
-Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use Google Gemini.
+Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use hosted providers such as Google Gemini or OpenAI.
 
 ---
 
@@ -85,11 +85,12 @@ Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a lo
 
   The repository pins `.python-version` to 3.11.13.
 
-- **One LLM backend** (either of them)
+- **One LLM backend**
 
   - **Ollama** for local models
     Install from the [official site](https://ollama.com/), then run `ollama serve`.
   - **Google Gemini** if you have an API key, get it from [here](https://aistudio.google.com/api-keys).
+  - **OpenAI** if you have an API key, get it from the [OpenAI API dashboard](https://platform.openai.com/api-keys).
 
 ### Quick setup with pip
 
@@ -136,12 +137,13 @@ $ cp .env.example .env
 
 **Environment variables**
 
-| Variable         | Values                                      | Description                                                            |
-| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
-| `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
-| `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
+| Variable         | Values                                                  | Description                                                            |
+| ---------------- | ------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `LLM_PROVIDER`   | `ollama`, `gemini`, or `openai`                         | Chooses provider. Defaults to Ollama.                                  |
+| `DEFAULT_MODEL`  | for example `gemma3:4b`, `gemini-2.5-pro`, or `gpt-5.5` | Model name passed to the provider.                                     |
+| `GEMINI_API_KEY` | string                                                  | Required when `LLM_PROVIDER=gemini`.                                   |
+| `OPENAI_API_KEY` | string                                                  | Required when `LLM_PROVIDER=openai`.                                   |
+| `GITHUB_TOKEN`   | optional                                                | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
 
@@ -265,6 +267,13 @@ What happens:
 - Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
+
+### OpenAI
+
+- Set `LLM_PROVIDER=openai`
+- Set `DEFAULT_MODEL` to a supported OpenAI model, for example `gpt-5.5`
+- Provide `OPENAI_API_KEY`
+- The wrapper in `models.OpenAIProvider` calls `chat.completions.create` and adapts responses to the unified format
 
 ---
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,14 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import ModelProvider, OllamaProvider, GeminiProvider, OpenAIProvider
+from prompt import (
+    MODEL_PROVIDER_MAPPING,
+    GEMINI_API_KEY,
+    OPENAI_API_KEY,
+    PROVIDER,
+    CONFIGURED_PROVIDER,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,18 +51,29 @@ def initialize_llm_provider(model_name: str) -> Any:
         model_name: The name of the model to use
 
     Returns:
-        An initialized LLM provider (either OllamaProvider or GeminiProvider)
+        An initialized LLM provider
     """
-    # Default to Ollama provider
-    provider = OllamaProvider()
-    # If using Gemini and API key is available, use Gemini provider
-    model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
+    model_provider = (
+        ModelProvider(PROVIDER)
+        if CONFIGURED_PROVIDER
+        else MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
+    )
+
     if model_provider == ModelProvider.GEMINI:
         if not GEMINI_API_KEY:
-            logger.warning("⚠️ Gemini API key not found. Falling back to Ollama.")
+            logger.warning("Gemini API key not found. Falling back to Ollama.")
+            return OllamaProvider()
         else:
-            logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
-            provider = GeminiProvider(api_key=GEMINI_API_KEY)
-    else:
-        logger.info(f"🔄 Using Ollama provider with model {model_name}")
-    return provider
+            logger.info(f"Using Google Gemini API provider with model {model_name}")
+            return GeminiProvider(api_key=GEMINI_API_KEY)
+
+    if model_provider == ModelProvider.OPENAI:
+        if not OPENAI_API_KEY:
+            logger.warning("OpenAI API key not found. Falling back to Ollama.")
+            return OllamaProvider()
+        else:
+            logger.info(f"Using OpenAI API provider with model {model_name}")
+            return OpenAIProvider(api_key=OPENAI_API_KEY)
+
+    logger.info(f"Using Ollama provider with model {model_name}")
+    return OllamaProvider()

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    OPENAI = "openai"
 
 
 @runtime_checkable
@@ -19,7 +20,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -281,7 +282,7 @@ class OllamaProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -324,7 +325,7 @@ class GeminiProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Google Gemini API."""
         import re
@@ -375,7 +376,7 @@ class GeminiProvider:
                 api_hint = float(match.group(1)) if match else None
 
                 # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
-                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
 
                 # Prefer the API hint when it is shorter than our computed delay
                 delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay
@@ -389,3 +390,73 @@ class GeminiProvider:
                     f"Retrying in {sleep_time}s..."
                 )
                 time.sleep(sleep_time)
+
+
+class OpenAIProvider:
+    """OpenAI API provider implementation."""
+
+    def __init__(self, api_key: str):
+        try:
+            from openai import OpenAI
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "OpenAI provider requires the 'openai' package. "
+                "Install dependencies with: pip install -r requirements.txt"
+            ) from exc
+
+        self.client = OpenAI(api_key=api_key)
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Send a chat request to OpenAI."""
+
+        openai_options = options.copy() if options else {}
+        openai_options.pop("stream", None)
+
+        chat_params = {
+            "model": model,
+            "messages": messages,
+        }
+
+        if "temperature" in openai_options:
+            chat_params["temperature"] = openai_options["temperature"]
+        if "top_p" in openai_options:
+            chat_params["top_p"] = openai_options["top_p"]
+
+        if kwargs.get("stream") is not None:
+            chat_params["stream"] = kwargs["stream"]
+
+        response_format = self._build_response_format(kwargs.get("format"))
+        if response_format:
+            chat_params["response_format"] = response_format
+
+        response = self.client.chat.completions.create(**chat_params)
+        message = response.choices[0].message
+
+        return {
+            "message": {
+                "role": message.role or "assistant",
+                "content": message.content or "",
+            }
+        }
+
+    def _build_response_format(self, schema: Any) -> Optional[Dict[str, Any]]:
+        if not schema:
+            return None
+
+        if isinstance(schema, dict):
+            return {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "hiring_agent_response",
+                    "schema": schema,
+                    "strict": False,
+                },
+            }
+
+        return None

--- a/prompt.py
+++ b/prompt.py
@@ -18,11 +18,13 @@ DEFAULT_PROVIDER = ModelProvider.OLLAMA
 
 # Get model and provider from environment or use defaults
 DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", DEFAULT_MODEL_NAME)
-PROVIDER = os.getenv("LLM_PROVIDER", DEFAULT_PROVIDER.value)
+CONFIGURED_PROVIDER = os.getenv("LLM_PROVIDER")
+PROVIDER = CONFIGURED_PROVIDER or DEFAULT_PROVIDER.value
 
 # Validate provider
 if PROVIDER not in [p.value for p in ModelProvider]:
     PROVIDER = DEFAULT_PROVIDER.value
+    CONFIGURED_PROVIDER = None
 
 # Model-specific parameters
 MODEL_PARAMETERS = {
@@ -41,6 +43,13 @@ MODEL_PARAMETERS = {
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # OpenAI models
+    "gpt-5.5": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-5.4": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-4.1": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-4.1-mini": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-4o": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-4o-mini": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -61,7 +70,15 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
+    # OpenAI models
+    "gpt-5.5": ModelProvider.OPENAI,
+    "gpt-5.4": ModelProvider.OPENAI,
+    "gpt-4.1": ModelProvider.OPENAI,
+    "gpt-4.1-mini": ModelProvider.OPENAI,
+    "gpt-4o": ModelProvider.OPENAI,
+    "gpt-4o-mini": ModelProvider.OPENAI,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ requests==2.32.4
 pymupdf4llm==0.0.27
 Jinja2==3.1.6
 google-generativeai==0.4.0
+openai>=1.40.0
 python-dotenv==1.0.1
 black==25.9.0


### PR DESCRIPTION
## Summary

Adds OpenAI as a configurable LLM provider alongside Ollama and Gemini.

## Changes

- Adds ModelProvider.OPENAI and an OpenAIProvider wrapper.
- Routes LLM_PROVIDER=openai through OPENAI_API_KEY while preserving existing model-name mapping behavior.
- Adds OpenAI model defaults and the official OpenAI Python SDK dependency.
- Updates .env.example, README provider docs, and contributor smoke-check guidance.

## Validation

- .venv\\Scripts\\python.exe -m py_compile models.py llm_utils.py prompt.py evaluator.py pdf.py github.py score.py
- OpenAI provider initialization smoke check with a test API key and installed SDK.

## Notes

No live OpenAI API call was run; validation covered provider initialization and local import/runtime compatibility.