### PR TITLE
Handle invalid GitHub rate limit headers

### DIFF
--- a/github.py
+++ b/github.py
@@ -26,6 +26,17 @@ def _create_cache_filename(api_url: str, params: dict = None) -> str:
     return filename
 
 
+def _parse_rate_limit_header(value: Optional[str], header_name: str) -> Optional[int]:
+    if value is None:
+        return None
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(f"Ignoring invalid GitHub {header_name} header: {value!r}")
+        return None
+
+
 def _fetch_github_api(api_url, params=None):
     headers = {}
     github_token = os.environ.get("GITHUB_TOKEN")
@@ -60,13 +71,18 @@ def _fetch_github_api(api_url, params=None):
         f"{rate_limit_remaining}/{rate_limit_limit}. Reset at {rate_limit_reset}"
     )
 
-    if rate_limit_remaining is not None and rate_limit_limit is not None:
-        remaining = int(rate_limit_remaining)
-        limit = int(rate_limit_limit)
+    remaining = _parse_rate_limit_header(
+        rate_limit_remaining, "X-RateLimit-Remaining"
+    )
+    limit = _parse_rate_limit_header(rate_limit_limit, "X-RateLimit-Limit")
+    reset_timestamp = _parse_rate_limit_header(
+        rate_limit_reset, "X-RateLimit-Reset"
+    )
+
+    if remaining is not None and limit is not None:
 
         # Log rate limit information and handle proactively
-        if remaining < 10 and rate_limit_reset:
-            reset_timestamp = int(rate_limit_reset)
+        if remaining < 10 and reset_timestamp is not None:
             current_timestamp = int(time.time())
             wait_seconds = (
                 max(0, reset_timestamp - current_timestamp) + 5

--- a/tests/github_rate_limit_test.py
+++ b/tests/github_rate_limit_test.py
@@ -1,0 +1,51 @@
+import sys
+import types
+import unittest
+
+
+sys.modules.setdefault("requests", types.SimpleNamespace())
+sys.modules.setdefault("models", types.SimpleNamespace(GitHubProfile=object))
+sys.modules.setdefault(
+    "pdf",
+    types.SimpleNamespace(
+        logger=types.SimpleNamespace(warning=lambda *args, **kwargs: None)
+    ),
+)
+sys.modules.setdefault(
+    "prompts.template_manager",
+    types.SimpleNamespace(TemplateManager=object),
+)
+sys.modules.setdefault(
+    "prompt", types.SimpleNamespace(DEFAULT_MODEL="test", MODEL_PARAMETERS={})
+)
+sys.modules.setdefault(
+    "llm_utils",
+    types.SimpleNamespace(
+        initialize_llm_provider=lambda *args, **kwargs: None,
+        extract_json_from_response=lambda value: value,
+    ),
+)
+sys.modules.setdefault("config", types.SimpleNamespace(DEVELOPMENT_MODE=False))
+from github import _parse_rate_limit_header
+
+
+class GitHubRateLimitHeaderTests(unittest.TestCase):
+    def test_parse_valid_rate_limit_header(self):
+        self.assertEqual(
+            _parse_rate_limit_header("42", "X-RateLimit-Remaining"),
+            42,
+        )
+
+    def test_parse_missing_rate_limit_header(self):
+        self.assertIsNone(
+            _parse_rate_limit_header(None, "X-RateLimit-Remaining"),
+        )
+
+    def test_parse_invalid_rate_limit_header(self):
+        self.assertIsNone(
+            _parse_rate_limit_header("not-an-int", "X-RateLimit-Remaining"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a small parser for GitHub rate-limit headers
- ignore malformed/missing rate-limit header values instead of raising during GitHub API fetches
- cover valid, missing, and invalid header values with a focused unittest

## Verification

- python -m unittest tests.github_rate_limit_test
- python -m py_compile github.py tests/github_rate_limit_test.py
