### PR TITLE
Read nested GitHub profile data in CSV export

### DIFF
--- a/tests/transform_github_csv_test.py
+++ b/tests/transform_github_csv_test.py
@@ -1,0 +1,51 @@
+import sys
+import types
+import unittest
+
+
+sys.modules.setdefault("models", types.SimpleNamespace(JSONResume=object))
+
+from transform import transform_evaluation_response
+
+
+class TransformGitHubCsvTests(unittest.TestCase):
+    def test_uses_nested_github_profile_data(self):
+        row = transform_evaluation_response(
+            github_data={
+                "profile": {
+                    "public_repos": 12,
+                    "followers": 34,
+                    "following": 5,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "bio": "Software engineer",
+                },
+                "projects": [],
+            }
+        )
+
+        self.assertEqual(row["github_repos"], 12)
+        self.assertEqual(row["github_followers"], 34)
+        self.assertEqual(row["github_following"], 5)
+        self.assertEqual(row["github_created_at"], "2024-01-01T00:00:00Z")
+        self.assertEqual(row["github_bio"], "Software engineer")
+
+    def test_supports_flat_github_data_for_compatibility(self):
+        row = transform_evaluation_response(
+            github_data={
+                "public_repos": 7,
+                "followers": 8,
+                "following": 9,
+                "created_at": "2025-01-01T00:00:00Z",
+                "bio": "Builder",
+            }
+        )
+
+        self.assertEqual(row["github_repos"], 7)
+        self.assertEqual(row["github_followers"], 8)
+        self.assertEqual(row["github_following"], 9)
+        self.assertEqual(row["github_created_at"], "2025-01-01T00:00:00Z")
+        self.assertEqual(row["github_bio"], "Builder")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/transform.py
+++ b/transform.py
@@ -657,11 +657,12 @@ def transform_evaluation_response(
 
     # Extract GitHub data
     if github_data:
-        csv_row["github_repos"] = github_data.get("public_repos", 0)
-        csv_row["github_followers"] = github_data.get("followers", 0)
-        csv_row["github_following"] = github_data.get("following", 0)
-        csv_row["github_created_at"] = github_data.get("created_at", "")
-        csv_row["github_bio"] = github_data.get("bio", "")
+        github_profile = github_data.get("profile", github_data)
+        csv_row["github_repos"] = github_profile.get("public_repos", 0)
+        csv_row["github_followers"] = github_profile.get("followers", 0)
+        csv_row["github_following"] = github_profile.get("following", 0)
+        csv_row["github_created_at"] = github_profile.get("created_at", "")
+        csv_row["github_bio"] = github_profile.get("bio", "")
     else:
         csv_row["github_repos"] = 0
         csv_row["github_followers"] = 0


### PR DESCRIPTION
## Summary

- read GitHub profile fields from the nested `github_data.profile` shape produced by `fetch_and_display_github_info`
- keep compatibility with older flat GitHub dictionaries
- add unit coverage for both nested and flat inputs

## Verification

- python -m unittest tests.transform_github_csv_test
- python -m py_compile transform.py tests/transform_github_csv_test.py
