### PR TITLE
Parse unicode dash date ranges

### DIFF
--- a/tests/transform_date_range_test.py
+++ b/tests/transform_date_range_test.py
@@ -1,0 +1,23 @@
+import sys
+import types
+import unittest
+
+
+sys.modules.setdefault("models", types.SimpleNamespace(JSONResume=object))
+
+from transform import parse_date_range
+
+
+class TransformDateRangeTests(unittest.TestCase):
+    def test_parse_month_range_with_en_dash(self):
+        self.assertEqual(parse_date_range("Jan–Mar 2021"), ("Jan 2021", "Mar 2021"))
+
+    def test_parse_year_range_with_en_dash(self):
+        self.assertEqual(parse_date_range("2020–2021"), ("2020-01", "2021-12"))
+
+    def test_parse_year_range_with_em_dash(self):
+        self.assertEqual(parse_date_range("2020—2021"), ("2020-01", "2021-12"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/transform.py
+++ b/transform.py
@@ -417,6 +417,8 @@ def parse_date_range(date_range: str) -> tuple:
     if not date_range:
         return None, None
 
+    date_range = date_range.replace("–", "-").replace("—", "-")
+
     # Handle "onwards" case
     if "onwards" in date_range:
         # Extract the start date from "onwards" format


### PR DESCRIPTION
## Summary

- normalize en dash and em dash characters before parsing date ranges
- allow month ranges such as `Jan–Mar 2021` and year ranges such as `2020—2021` to follow the existing hyphen parsing path
- add focused unit coverage for unicode dash month and year ranges

## Verification

- python -m unittest tests.transform_date_range_test
- python -m py_compile transform.py tests/transform_date_range_test.py
