### PR TITLE
Preserve fallback project links

### DIFF
--- a/tests/transform_project_url_test.py
+++ b/tests/transform_project_url_test.py
@@ -1,0 +1,56 @@
+import sys
+import types
+import unittest
+
+
+sys.modules.setdefault("models", types.SimpleNamespace(JSONResume=object))
+
+from transform import transform_projects
+
+
+class TransformProjectUrlTests(unittest.TestCase):
+    def test_uses_github_url_when_url_is_missing(self):
+        projects = transform_projects(
+            [
+                {
+                    "name": "Example",
+                    "description": "Example project",
+                    "github_url": "https://github.com/example/project",
+                    "technologies": ["Python"],
+                }
+            ]
+        )
+
+        self.assertEqual(projects[0]["url"], "https://github.com/example/project")
+
+    def test_uses_live_url_when_url_and_github_url_are_missing(self):
+        projects = transform_projects(
+            [
+                {
+                    "name": "Example",
+                    "description": "Example project",
+                    "live_url": "https://example.com",
+                    "technologies": ["Python"],
+                }
+            ]
+        )
+
+        self.assertEqual(projects[0]["url"], "https://example.com")
+
+    def test_preserves_explicit_url_over_fallbacks(self):
+        projects = transform_projects(
+            [
+                {
+                    "name": "Example",
+                    "url": "https://docs.example.com",
+                    "github_url": "https://github.com/example/project",
+                    "live_url": "https://example.com",
+                }
+            ]
+        )
+
+        self.assertEqual(projects[0]["url"], "https://docs.example.com")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/transform.py
+++ b/transform.py
@@ -337,7 +337,9 @@ def transform_projects(projects_list: List) -> List[Dict]:
                     "endDate": None,
                     "description": item.get("description", ""),
                     "highlights": [item.get("type", "")] if item.get("type") else [],
-                    "url": item.get("url", None),
+                    "url": item.get("url")
+                    or item.get("github_url")
+                    or item.get("live_url"),
                     "technologies": technologies,
                     "skills": skills,
                 }


### PR DESCRIPTION
## Summary

- preserve project links when parsed project data provides `github_url` or `live_url` instead of `url`
- keep explicit `url` values preferred over fallbacks
- add unit coverage for GitHub, live, and explicit URL behavior

## Verification

- python -m unittest tests.transform_project_url_test
- python -m py_compile transform.py tests/transform_project_url_test.py
