### PR TITLE
chore: remove unused imports in pdf, evaluator, and score modules

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -4,7 +4,6 @@ from models import JSONResume, EvaluationData
 from llm_utils import initialize_llm_provider, extract_json_from_response
 import logging
 import json
-import re
 
 MAX_BONUS_POINTS = 20
 MIN_FINAL_SCORE = -20

--- a/pdf.py
+++ b/pdf.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import json
 import time
 import logging

--- a/score.py
+++ b/score.py
@@ -6,7 +6,7 @@ import csv
 from pdf import PDFHandler
 from github import fetch_and_display_github_info
 from models import JSONResume, EvaluationData
-from typing import List, Optional, Dict
+from typing import Optional
 from evaluator import ResumeEvaluator
 from pathlib import Path
 from prompt import DEFAULT_MODEL, MODEL_PARAMETERS


### PR DESCRIPTION
### Description
Removed unused standard library imports that were left behind in the codebase to improve readability.

- Removed `sys` from `pdf.py`
- Removed `re` from `evaluator.py`
- Removed `List` and `Dict` from `score.py` (kept `Optional` as it is required for the `_evaluate_resume` return type)

Closes #262