### PR TITLE
feat: add Ollama Cloud support via OLLAMA_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ DEFAULT_MODEL=gemma3:4b
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# Ollama Cloud API Key (optional, for using Ollama Cloud instead of local)
+# Get your key from https://ollama.com (free tier available)
+OLLAMA_API_KEY=your_ollama_api_key_here

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a lo
 
   - **Ollama** for local models
     Install from the [official site](https://ollama.com/), then run `ollama serve`.
+  - **Ollama Cloud** for hosted models without a local GPU.
+    Get an API key from [Ollama Cloud](https://ollama.com) (free tier available).
   - **Google Gemini** if you have an API key, get it from [here](https://aistudio.google.com/api-keys).
 
 ### Quick setup with pip
@@ -124,6 +126,9 @@ $ ollama pull gemma3:12b
 $ ollama pull gemma3:1b
 ```
 
+> **Ollama Cloud users** can skip `ollama pull` and use larger models like `gemma4:31b`
+> without local hardware. Set `OLLAMA_API_KEY` in your `.env` file (see [Configuration](#configuration)).
+
 ---
 
 ## Configuration
@@ -141,6 +146,7 @@ $ cp .env.example .env
 | `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
 | `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
 | `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
+| `OLLAMA_API_KEY` | optional                                    | Enables [Ollama Cloud](https://ollama.com) instead of local Ollama.    |
 | `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
@@ -253,11 +259,18 @@ What happens:
 
 ## Provider details
 
-### Ollama
+### Ollama (local)
 
 - Set `LLM_PROVIDER=ollama`
 - Set `DEFAULT_MODEL` to any pulled model, for example `gemma3:4b`
 - The provider wrapper in `models.OllamaProvider` calls `ollama.chat`
+
+### Ollama Cloud
+
+- Set `LLM_PROVIDER=ollama`
+- Set `DEFAULT_MODEL` to a supported cloud model, for example `gemma4:31b`
+- Set `OLLAMA_API_KEY` to your API key from [ollama.com](https://ollama.com)
+- No local GPU or `ollama serve` required
 
 ### Gemini
 

--- a/models.py
+++ b/models.py
@@ -19,7 +19,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -272,16 +272,24 @@ class OllamaProvider:
     """Ollama LLM provider implementation."""
 
     def __init__(self):
+        import os
         import ollama
 
-        self.client = ollama
+        api_key = os.getenv("OLLAMA_API_KEY", "")
+        if api_key:
+            self.client = ollama.Client(
+                host="https://ollama.com",
+                headers={"Authorization": "Bearer " + api_key},
+            )
+        else:
+            self.client = ollama.Client()
 
     def chat(
         self,
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -324,7 +332,7 @@ class GeminiProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Google Gemini API."""
         import re
@@ -375,7 +383,7 @@ class GeminiProvider:
                 api_hint = float(match.group(1)) if match else None
 
                 # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
-                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
 
                 # Prefer the API hint when it is shorter than our computed delay
                 delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay


### PR DESCRIPTION
Closes #263 

## Problem

The tool only supports local Ollama (requires a GPU) or Google Gemini (rate-limited free tier). Users without local GPUs have no easy way to run evaluations.

## Solution

Detect `OLLAMA_API_KEY` in `OllamaProvider.__init__`. When set, create an authenticated `ollama.Client` pointing to `https://ollama.com`. When unset, fall back to a local `ollama.Client()`.

This is a minimal change: one env var, no model name conventions, no new config flags. Users set their API key and use the same model names they would locally (e.g. `gemma4:31b`).

### Changes
- **models.py**: Use `ollama.Client()` instead of assigning the `ollama` module directly. Detect `OLLAMA_API_KEY` for cloud routing.
- **.env.example**: Document the new optional variable.
- **README.md**: Add Ollama Cloud to the backend list, env vars table, and provider details section.

## Testing

Tested end-to-end on Windows with `OLLAMA_API_KEY` set and `DEFAULT_MODEL=gemma4:31b`. Full pipeline (PDF parse, section extraction, GitHub enrichment, evaluation) completed successfully with a score output.