### PR TITLE
Fix logger output stream handling

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -79,7 +79,7 @@ class ResumeEvaluator:
 
             response_text = response["message"]["content"]
             response_text = extract_json_from_response(response_text)
-            logger.error(f"🔤 Prompt response: {response_text}")
+            logger.info(f"🔤 Prompt response: {response_text}")
 
             evaluation_dict = json.loads(response_text)
             evaluation_data = EvaluationData(**evaluation_dict)

--- a/score.py
+++ b/score.py
@@ -19,11 +19,25 @@ from transform import (
 from config import DEVELOPMENT_MODE
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)5s - %(lineno)5d - %(funcName)33s - %(levelname)5s - %(message)s",
+formatter = logging.Formatter(
+    "%(asctime)s - %(name)5s - %(lineno)5d - %(funcName)33s - %(levelname)5s - %(message)s"
 )
+
+stdout_handler = logging.StreamHandler(sys.stdout)
+stdout_handler.setLevel(logging.INFO)
+stdout_handler.addFilter(
+    lambda record: record.levelno < logging.ERROR
+)
+stdout_handler.setFormatter(formatter)
+
+stderr_handler = logging.StreamHandler(sys.stderr)
+stderr_handler.setLevel(logging.ERROR)
+stderr_handler.setFormatter(formatter)
+
+logger.addHandler(stdout_handler)
+logger.addHandler(stderr_handler)
 
 
 def print_evaluation_results(


### PR DESCRIPTION
## Description

This PR updates the logging configuration to correctly separate log messages between stdout and stderr.

## Changes Made

- Configured logging handlers to route informational logs (`INFO`) to stdout.
- Configured error logs (`ERROR`) to stderr.
- Prevented `logger.info()` messages from appearing in `subprocess` stderr output.
- Improved subprocess output handling by ensuring stderr contains only actual errors.

## Motivation

Previously, all logger messages were written to stderr due to the default `logging.StreamHandler` behavior. This caused normal informational logs to be incorrectly treated as errors when capturing subprocess output.

## Testing

- Verified that `logger.info()` messages appear in `stdout`.
- Verified that `logger.error()` messages appear in `stderr`.
- Confirmed subprocess output handling works as expected.

Closes #267