### PR TITLE
fix: enforce GitHub author commit threshold

### DIFF
--- a/github.py
+++ b/github.py
@@ -338,7 +338,7 @@ def generate_projects_json(projects: List[Dict]) -> List[Dict]:
     try:
         projects_data = []
         for project in projects:
-            if project.get("author_commit_count") == 0:
+            if (project.get("author_commit_count") or 0) < 4:
                 continue
 
             project_data = {
@@ -402,6 +402,8 @@ def generate_projects_json(projects: List[Dict]) -> List[Dict]:
             seen_names = set()
 
             for project in selected_projects:
+                if (project.get("author_commit_count") or 0) < 4:
+                    continue
                 project_name = project.get("name", "")
                 if project_name and project_name not in seen_names:
                     unique_projects.append(project)


### PR DESCRIPTION
## Summary

Enforces the existing GitHub project selection rule that selected repositories must have at least 4 author commits.

Previously, the prompt required `author_commit_count >= 4`, but the code only filtered out repositories with exactly `0` author commits. As a result, repositories with 1-3 author commits could still be passed to the LLM and returned in the final selected GitHub projects.

## Changes

- Filters candidate GitHub projects before LLM selection when `author_commit_count < 4`.
- Filters LLM-selected projects again before returning them, so invalid selections cannot pass through even if the model returns them.

## Validation
- Ran the resume workflow against a GitHub account
- Ran `python -m py_compile github.py`
- Confirmed repos < 4 were not included

Closes #269