### PR TITLE
Add Anthropic Claude provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,16 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "anthropic"
 LLM_PROVIDER=ollama
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For Anthropic: "claude-sonnet-4-6", "claude-opus-4-8",
+# or "claude-haiku-4-5-20251001"
 DEFAULT_MODEL=gemma3:4b
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# Anthropic API Key (required if using Anthropic/Claude provider)
+ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Overview
 
-Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use Google Gemini.
+Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use Google Gemini or Anthropic Claude.
 
 ---
 
@@ -90,6 +90,7 @@ Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a lo
   - **Ollama** for local models
     Install from the [official site](https://ollama.com/), then run `ollama serve`.
   - **Google Gemini** if you have an API key, get it from [here](https://aistudio.google.com/api-keys).
+  - **Anthropic Claude** if you have an API key, get it from [here](https://console.anthropic.com/).
 
 ### Quick setup with pip
 
@@ -138,9 +139,10 @@ $ cp .env.example .env
 
 | Variable         | Values                                      | Description                                                            |
 | ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
+| `LLM_PROVIDER`   | `ollama`, `gemini`, or `anthropic`          | Chooses provider. Defaults to Ollama.                                  |
+| `DEFAULT_MODEL`  | for example `gemma3:4b`, `gemini-2.5-pro`, or `claude-sonnet-4-6` | Model name passed to the provider.                   |
 | `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
+| `ANTHROPIC_API_KEY` | string                                   | Required when `LLM_PROVIDER=anthropic`.                                |
 | `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
@@ -265,6 +267,13 @@ What happens:
 - Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
+
+### Anthropic Claude
+
+- Set `LLM_PROVIDER=anthropic`
+- Set `DEFAULT_MODEL` to a supported Claude model, for example `claude-sonnet-4-6`, `claude-opus-4-8`, or `claude-haiku-4-5-20251001`
+- Provide `ANTHROPIC_API_KEY`
+- The wrapper in `models.AnthropicProvider` adapts responses to a unified format
 
 ---
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -51,7 +51,7 @@ def initialize_llm_provider(model_name: str) -> Any:
     # Default to Ollama provider
     provider = OllamaProvider()
     # If using Gemini and API key is available, use Gemini provider
-    if os.getenv("LLM_PROVIDER"):
+    if "LLM_PROVIDER" in os.environ:
         model_provider = ModelProvider(PROVIDER)
     else:
         model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,8 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import AnthropicProvider, ModelProvider, OllamaProvider, GeminiProvider
+from prompt import ANTHROPIC_API_KEY, GEMINI_API_KEY, MODEL_PROVIDER_MAPPING
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ def initialize_llm_provider(model_name: str) -> Any:
         model_name: The name of the model to use
 
     Returns:
-        An initialized LLM provider (either OllamaProvider or GeminiProvider)
+        An initialized LLM provider.
     """
     # Default to Ollama provider
     provider = OllamaProvider()
@@ -57,6 +57,13 @@ def initialize_llm_provider(model_name: str) -> Any:
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.ANTHROPIC:
+        if not ANTHROPIC_API_KEY:
+            raise ValueError(
+                "ANTHROPIC_API_KEY is required when using the Anthropic/Claude provider."
+            )
+        logger.info(f"🔄 Using Anthropic Claude API provider with model {model_name}")
+        provider = AnthropicProvider(api_key=ANTHROPIC_API_KEY)
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
     return provider

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -3,9 +3,10 @@ Utility functions for LLM providers.
 """
 
 import logging
+import os
 from typing import Any, Dict, Optional
 from models import AnthropicProvider, ModelProvider, OllamaProvider, GeminiProvider
-from prompt import ANTHROPIC_API_KEY, GEMINI_API_KEY, MODEL_PROVIDER_MAPPING
+from prompt import ANTHROPIC_API_KEY, GEMINI_API_KEY, MODEL_PROVIDER_MAPPING, PROVIDER
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,11 @@ def initialize_llm_provider(model_name: str) -> Any:
     # Default to Ollama provider
     provider = OllamaProvider()
     # If using Gemini and API key is available, use Gemini provider
-    model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
+    if os.getenv("LLM_PROVIDER"):
+        model_provider = ModelProvider(PROVIDER)
+    else:
+        model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
+
     if model_provider == ModelProvider.GEMINI:
         if not GEMINI_API_KEY:
             logger.warning("⚠️ Gemini API key not found. Falling back to Ollama.")

--- a/models.py
+++ b/models.py
@@ -349,6 +349,8 @@ class AnthropicProvider:
         if options:
             if "temperature" in options:
                 request_params["temperature"] = options["temperature"]
+            if "top_p" in options:
+                request_params["top_p"] = options["top_p"]
 
         if "format" in kwargs:
             request_params["tools"] = [

--- a/models.py
+++ b/models.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Dict, Tuple, Any, Protocol, runtime_checkable
 from pydantic import BaseModel, Field, field_validator
 from enum import Enum
+import json
 
 
 class ModelProvider(Enum):
@@ -8,6 +9,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    ANTHROPIC = "anthropic"
 
 
 @runtime_checkable
@@ -308,6 +310,73 @@ class OllamaProvider:
             chat_params["format"] = kwargs["format"]
 
         return self.client.chat(**chat_params)
+
+
+class AnthropicProvider:
+    """Anthropic Claude LLM provider implementation."""
+
+    def __init__(self, api_key: str):
+        import anthropic
+
+        self.client = anthropic.Anthropic(api_key=api_key)
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Send a chat request to Anthropic and return an Ollama-like response."""
+        system_messages = [
+            msg["content"] for msg in messages if msg.get("role") == "system"
+        ]
+        anthropic_messages = [
+            {"role": msg["role"], "content": msg["content"]}
+            for msg in messages
+            if msg.get("role") in {"user", "assistant"}
+        ]
+
+        request_params = {
+            "model": model,
+            "max_tokens": 4096,
+            "messages": anthropic_messages,
+        }
+
+        if system_messages:
+            request_params["system"] = "\n\n".join(system_messages)
+
+        if options:
+            if "temperature" in options:
+                request_params["temperature"] = options["temperature"]
+
+        if "format" in kwargs:
+            request_params["tools"] = [
+                {
+                    "name": "return_json",
+                    "description": "Return the requested response as valid JSON.",
+                    "input_schema": kwargs["format"],
+                }
+            ]
+            request_params["tool_choice"] = {"type": "tool", "name": "return_json"}
+
+        response = self.client.messages.create(**request_params)
+
+        for block in response.content:
+            if block.type == "tool_use" and block.name == "return_json":
+                return {
+                    "message": {
+                        "role": "assistant",
+                        "content": json.dumps(block.input),
+                    }
+                }
+
+        text = "".join(
+            block.text
+            for block in response.content
+            if getattr(block, "type", None) == "text"
+        )
+        return {"message": {"role": "assistant", "content": text}}
 
 
 class GeminiProvider:

--- a/prompt.py
+++ b/prompt.py
@@ -41,6 +41,10 @@ MODEL_PARAMETERS = {
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # Anthropic Claude models
+    "claude-sonnet-4-6": {"temperature": 0.1, "top_p": 0.9},
+    "claude-opus-4-8": {"temperature": 0.1, "top_p": 0.9},
+    "claude-haiku-4-5-20251001": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -61,7 +65,12 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
+    # Anthropic Claude models
+    "claude-sonnet-4-6": ModelProvider.ANTHROPIC,
+    "claude-opus-4-8": ModelProvider.ANTHROPIC,
+    "claude-haiku-4-5-20251001": ModelProvider.ANTHROPIC,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Jinja2==3.1.6
 google-generativeai==0.4.0
 python-dotenv==1.0.1
 black==25.9.0
+anthropic


### PR DESCRIPTION
## Summary
Adds Anthropic Claude as a supported LLM provider alongside Ollama and Gemini.

## Changes
- Adds an Anthropic provider implementation using the Messages API.
- Maps modern Claude model IDs for Sonnet, Opus, and Haiku.
- Adds ANTHROPIC_API_KEY configuration.
- Updates setup documentation and requirements.

## Testing
- Ran Python compile checks for provider/config files.
- Verified whitespace with git diff --check.