### PR TITLE
fix(models): retry transient Gemini errors (504/503/500) and extend request timeout

### DIFF
--- a/models.py
+++ b/models.py
@@ -330,11 +330,18 @@ class GeminiProvider:
         import re
         import time
         import random
-        from google.api_core.exceptions import ResourceExhausted
+        from google.api_core.exceptions import (
+            ResourceExhausted,
+            DeadlineExceeded,
+            ServiceUnavailable,
+            InternalServerError,
+        )
 
         MAX_RETRIES = 5
         BASE_DELAY = 10.0  # seconds — base for exponential backoff
         MAX_DELAY = 120.0  # cap so we never wait more than 2 minutes
+        REQUEST_TIMEOUT = 600.0  # per-request deadline; SDK default (~60s) is too
+        # short for larger sections and triggers 504 DeadlineExceeded errors
 
         # Map options to Gemini parameters
         generation_config = {}
@@ -358,10 +365,29 @@ class GeminiProvider:
         for attempt in range(MAX_RETRIES):
             try:
                 # Send the chat request
-                response = gemini_model.generate_content(gemini_messages)
+                response = gemini_model.generate_content(
+                    gemini_messages,
+                    request_options={"timeout": REQUEST_TIMEOUT},
+                )
 
                 # Convert Gemini response to Ollama-like format for compatibility
                 return {"message": {"role": "assistant", "content": response.text}}
+
+            except (DeadlineExceeded, ServiceUnavailable, InternalServerError) as e:
+                # Transient server-side errors (504/503/500). Retry with backoff
+                # rather than aborting the whole extraction on a single hiccup.
+                if attempt == MAX_RETRIES - 1:
+                    raise
+
+                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                sleep_time = round(exp_delay * random.uniform(0.8, 1.2), 2)
+
+                print(
+                    f"[GeminiProvider] Transient error {type(e).__name__} "
+                    f"(attempt {attempt + 1}/{MAX_RETRIES}). "
+                    f"Retrying in {sleep_time}s..."
+                )
+                time.sleep(sleep_time)
 
             except ResourceExhausted as e:
                 if attempt == MAX_RETRIES - 1:


### PR DESCRIPTION
## Summary

Fixes the Gemini provider aborting resume extraction on transient `504 Deadline expired` errors.

Two changes in `GeminiProvider.chat()` (`models.py`):

1. **Extend the per-request deadline.** Pass `request_options={"timeout": 600}` to `generate_content()`. The SDK's default per-request gRPC deadline (~60s) is too short for larger section calls on `gemini-2.5-flash` / `gemini-3.5-flash`, which raised `DeadlineExceeded` (504).
2. **Retry transient server errors.** The backoff loop previously only handled `ResourceExhausted` (429). It now also retries `DeadlineExceeded` (504), `ServiceUnavailable` (503), and `InternalServerError` (500) using the same exponential-backoff-with-jitter logic.

Previously, a single transient 504 on any section caused `_extract_all_sections_separately` to abort the whole run with no output.

## Before / After

**Before** — one transient 504 aborts the entire extraction:

```
 Error calling LLM for projects section: 504 Deadline expired before operation could complete.
 Failed to extract projects section. Aborting extraction to prevent partial/invalid resume data.
```

**After** — transient errors are retried with backoff and the run completes:

```
[GeminiProvider] Transient error DeadlineExceeded (attempt 1/5). Retrying in 11.6s...
Total time for separate section extraction: 23.06 seconds
OVERALL SCORE: 75.0/100
```

## Testing

- Ran `python score.py <resume>.pdf` end to end with `LLM_PROVIDER=gemini`, `DEFAULT_MODEL=gemini-2.5-flash`.
- **Before:** extraction aborted with `504 Deadline expired before operation could complete.` on the `projects` / `awards` sections (reproduced across multiple runs).
- **After:** all six sections extract successfully, GitHub enrichment and evaluation complete, and a full report is produced.

## Notes

- No prompt changes; provider-agnostic behavior preserved.
- Matched the surrounding code style (existing `2 ** attempt` idiom, same retry-loop structure) rather than reformatting unrelated lines, to keep the diff focused on the fix.

Fixes #284
