### PR TITLE
feat: add full extraction and scoring pipeline for Publications

### DIFF
--- a/models.py
+++ b/models.py
@@ -199,7 +199,7 @@ class AwardsSection(BaseModel):
 
 
 class PublicationsSection(BaseModel):
-    """Awards section containing a list of awards."""
+    """Publications section containing a list of publications."""
 
     publications: Optional[List[Publication]] = None
 

--- a/models.py
+++ b/models.py
@@ -19,7 +19,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -198,6 +198,12 @@ class AwardsSection(BaseModel):
     awards: Optional[List[Award]] = None
 
 
+class PublicationsSection(BaseModel):
+    """Awards section containing a list of awards."""
+
+    publications: Optional[List[Publication]] = None
+
+
 class JSONResume(BaseModel):
     """Complete JSON Resume format model."""
 
@@ -281,7 +287,7 @@ class OllamaProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -324,7 +330,7 @@ class GeminiProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Google Gemini API."""
         import re
@@ -375,7 +381,7 @@ class GeminiProvider:
                 api_hint = float(match.group(1)) if match else None
 
                 # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
-                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
 
                 # Prefer the API hint when it is shorter than our computed delay
                 delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay

--- a/pdf.py
+++ b/pdf.py
@@ -19,6 +19,7 @@ from models import (
     SkillsSection,
     ProjectsSection,
     AwardsSection,
+    PublicationsSection,
 )
 from llm_utils import initialize_llm_provider, extract_json_from_response
 from pymupdf_rag import to_markdown
@@ -189,6 +190,17 @@ class PDFHandler:
             return None
         return self._call_llm_for_section("awards", resume_text, prompt, AwardsSection)
 
+    def extract_publications_section(self, resume_text: str) -> Optional[Dict]:
+        prompt = self.template_manager.render_template(
+            "publications", text_content=resume_text
+        )
+        if not prompt:
+            logger.error("❌ Failed to render publications template")
+            return None
+        return self._call_llm_for_section(
+            "publications", resume_text, prompt, PublicationsSection
+        )
+
     def extract_json_from_text(self, resume_text: str) -> Optional[JSONResume]:
         try:
             return self._extract_all_sections_separately(resume_text)
@@ -226,6 +238,7 @@ class PDFHandler:
             "skills": self.extract_skills_section,
             "projects": self.extract_projects_section,
             "awards": self.extract_awards_section,
+            "publications": self.extract_publications_section,
         }
 
         if section_name not in section_extractors:
@@ -268,7 +281,15 @@ class PDFHandler:
     ) -> Optional[JSONResume]:
         start_time = time.time()
 
-        sections = ["basics", "work", "education", "skills", "projects", "awards"]
+        sections = [
+            "basics",
+            "work",
+            "education",
+            "skills",
+            "projects",
+            "awards",
+            "publications",
+        ]
 
         complete_resume = {
             "basics": None,

--- a/prompts/template_manager.py
+++ b/prompts/template_manager.py
@@ -41,6 +41,7 @@ class TemplateManager:
             "skills": "skills.jinja",
             "projects": "projects.jinja",
             "awards": "awards.jinja",
+            "publications": "publications.jinja",
             "system_message": "system_message.jinja",
             "github_project_selection": "github_project_selection.jinja",
             "resume_evaluation_criteria": "resume_evaluation_criteria.jinja",

--- a/prompts/templates/publications.jinja
+++ b/prompts/templates/publications.jinja
@@ -1,0 +1,27 @@
+Extract ONLY the publications and research papers information from this resume.
+
+--- The input markdown starts here ---
+
+{{ text_content }}
+
+--- The input markdown ends here ---
+
+Return ONLY a JSON object with this structure:
+{
+  "publications": [
+    {
+      "name": "Publication title",
+      "publisher": "Journal or conference name",
+      "releaseDate": "Publication date or null",
+      "url": "Publication URL",
+      "summary": "Brief description or null"
+    }
+  ]
+}
+
+If there are no publications, return:
+{
+  "publications": []
+}
+
+**IMPORTANT**: Return ONLY valid JSON. Do not include any explanatory text.

--- a/prompts/templates/resume_evaluation_criteria.jinja
+++ b/prompts/templates/resume_evaluation_criteria.jinja
@@ -116,11 +116,33 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 ## BONUS POINTS (Maximum total: 20 points)
 - +5 points for Google Summer of Code (GSoC) participation
 - +3 points for Girl Script Summer of Code participation
+- +2-4 points for peer-reviewed publications (conference/journal papers)
+- +1-2 points for preprints (arXiv) or workshop papers
 - +3-5 points for startup founder/co-founder experience
 - +2-3 points for early-stage engineer experience (first 10-20 employees at a startup)
 - +2 points for portfolio website (GitHub URL in basics.url)
 - +1 point for LinkedIn profile
 - +1-3 points for high-quality technical blogs (if blog data provided)
+
+## PUBLICATIONS & RESEARCH BONUS
+
+Evaluate the `publications` array from the structured resume data.
+This is a BONUS only — candidates without publications are NOT penalized.
+
+Scoring:
+- Peer-reviewed paper at a top venue (NeurIPS, ICML, CVPR, ICLR, ACL, ICSE, SOSP, OSDI, SIGCOMM, IEEE, ACM):
+    +4 points per paper, max +8
+- Peer-reviewed paper at other venues/journals:
+    +2 points per paper, max +4
+- Preprint / arXiv (not peer-reviewed):
+    +1 point per paper, max +2
+- Workshop paper or technical report:
+    +1 point total
+
+**CRITICAL**: Publications bonus counts toward the 20-point bonus cap above.
+If no publications listed: add 0, do not penalize.
+Always cite paper title and venue in bonus_points.breakdown, e.g.:
+"Publications: +4 (1 peer-reviewed NeurIPS paper: 'Attention Is All You Need')"
 
 **CRITICAL**: The total bonus points cannot exceed 20 points under any circumstances.
 

--- a/transform.py
+++ b/transform.py
@@ -746,8 +746,6 @@ def transform_evaluation_response(
     ):
         publications = resume_data.publications
         csv_row["publications_count"] = len(publications)
-        print("*" * 50)
-        print(len(publications))
         csv_row["publications_titles"] = "; ".join(
             p.name for p in publications if p.name
         )

--- a/transform.py
+++ b/transform.py
@@ -738,6 +738,27 @@ def transform_evaluation_response(
     else:
         csv_row["areas_for_improvement"] = ""
 
+        # Extract publications summary
+    if (
+        resume_data
+        and hasattr(resume_data, "publications")
+        and resume_data.publications
+    ):
+        publications = resume_data.publications
+        csv_row["publications_count"] = len(publications)
+        print("*" * 50)
+        print(len(publications))
+        csv_row["publications_titles"] = "; ".join(
+            p.name for p in publications if p.name
+        )
+        csv_row["publications_venues"] = "; ".join(
+            p.publisher for p in publications if p.publisher
+        )
+    else:
+        csv_row["publications_count"] = 0
+        csv_row["publications_titles"] = ""
+        csv_row["publications_venues"] = ""
+
     return csv_row
 
 


### PR DESCRIPTION
***

### **Description:**
For AI/ML Engineering, Data Science, and R&D roles, publications are often the strongest indicator of a candidate's quality. Previously, the agent completely ignored research papers. 

If a researcher with published papers runs their resume through the current agent, their score will likely suffer because their work doesn't fit neatly into the "Open Source" or "Self Projects" buckets. There is currently no mention of publications while scoring the resume or evaluation prompts.

This PR implements a full end-to-end pipeline to extract, evaluate, and export academic publications, without breaking the base 100-point scoring system. Publications bonus counts toward the existing 20-point bonus cap, so a candidate  with GSoC (+5) and 2 papers (+6) gets capped at 20 total bonus, not 31.

### **Solution**
The standard JSON Resume schema already supports a `Publications` array as introduced by #70 . Since we have it we can expose this to the LLM evaluator and add a new scoring category **(Bonus-only)**, beacuse that way it doesn't penalize resume with no publications. A researcher with papers gets rewarded. A engineer with zero gets nothing deducted. 

### **Architectural Changes Implemented:**
1. **Data Extraction (`models.py`, `pdf.py`, `publications.jinja`):**
   - Created a new `PublicationsSection` Pydantic model (aligning with the standard JSON Resume schema).
   - Added `extract_publications_section()` to handle targeted LLM extraction.
   - Registered the new template in `template_manager.py`.
2. **Evaluation (`resume_evaluation_criteria.jinja`):**
   - Instructs the evaluator to read the extracted `publications` array.
   - Accurately scores peer-reviewed papers, preprints, and journals as `bonus_points` (capped to respect the existing 20-point max bonus limit so the base 100-point math remains stable).
3. **CSV Export (`transform.py`):**
   - Now it also writes `publications_count`, `publications_titles`, and `publications_venues` to `resume_evaluations.csv`.

### Files Changed:
- models.py — fixed PublicationsSection model
- pdf.py — added extract_publications_section(), registered in section_extractors
- prompts/templates/publications.jinja — new extraction template
- prompts/templates/resume_evaluation_criteria.jinja — added publications bonus scoring
- transform.py — added publications_count, publications_titles, publications_venues to CSV

### **Testing Performed:**
- [x] Code formatted with `black`.
- [x] Tested extraction with an actual resume containing publications and no publications.
- [x] Verified Pydantic models successfully parse the LLM JSON output.
- [x] Verified `resume_evaluations.csv` successfully appends the new columns.

**Example Terminal Output:**
Bonus section reflecting publication score.
```text
⭐ BONUS POINTS: 10.0
------------------------------
Publications: +6 (2 peer-reviewed papers: 'Predicting Alzheimer’s Disease' in Springer and 'On Renewable Energy Source Selection'); Portfolio/GitHub presence: +2
```

***