### PR TITLE
fix: make all resume sections optional except basics (fixes issue #278)

### DIFF
--- a/pdf.py
+++ b/pdf.py
@@ -268,7 +268,8 @@ class PDFHandler:
     ) -> Optional[JSONResume]:
         start_time = time.time()
 
-        sections = ["basics", "work", "education", "skills", "projects", "awards"]
+        required_sections = ["basics"]
+        optional_sections = ["work", "education", "skills", "projects", "awards"]
 
         complete_resume = {
             "basics": None,
@@ -286,7 +287,7 @@ class PDFHandler:
             "meta": None,
         }
 
-        for section_name in sections:
+        for section_name in required_sections:
             section_data = self._extract_section_data(text_content, section_name)
 
             if section_data:
@@ -297,6 +298,17 @@ class PDFHandler:
                     f"⚠️ Failed to extract {section_name} section. Aborting extraction to prevent partial/invalid resume data."
                 )
                 return None
+
+        for section_name in optional_sections:
+            section_data = self._extract_section_data(text_content, section_name)
+
+            if section_data:
+                complete_resume.update(section_data)
+                logger.debug(f"✅ Successfully extracted {section_name} section")
+            else:
+                logger.warning(
+                    f"⚠️ Could not extract {section_name} section (may not be present in resume). Continuing."
+                )
 
         try:
             if complete_resume.get("basics") and isinstance(


### PR DESCRIPTION
## Summary

- Any section the LLM failed to extract (e.g. awards on a resume with none) would abort the entire extraction pipeline
- Root cause: LLMs often return plain text instead of JSON for sections absent from a resume, triggering a `JSONDecodeError` → `None` return → fatal abort
- Fix: split `_extract_all_sections_separately` into `required_sections` and `optional_sections`; only `basics` is required, all other sections (`work`, `education`, `skills`, `projects`, `awards`) log a warning on failure and continue

## Before / After

**Before:**
ERROR - ⚠️ Failed to extract awards section. Aborting extraction to prevent partial/invalid resume data.



**After:**
WARNING - ⚠️ Could not extract awards section (may not be present in resume). Continuing.



## Smoke Tests

- ✅ Ollama (`gemma3:12b`) — resume without awards extracted fully, full evaluation printed
- ⚠️ Gemini (`gemini-2.0-flash`) — provider connected correctly, blocked by free-tier daily quota (not a code issue)

## Test plan

- [ ] Run `python score.py <resume_without_awards.pdf>` with Ollama — confirm no abort on missing sections
- [ ] Run same with Gemini when quota allows