### PR TITLE
feat: add OpenCode API provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,15 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "opencode"
 LLM_PROVIDER=ollama
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For OpenCode: "deepseek-v4-flash", etc.
 DEFAULT_MODEL=gemma3:4b
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# OpenCode API Key (required if using OpenCode provider)
+OPENCODE_API_KEY=your_opencode_api_key_here

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,8 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import ModelProvider, OllamaProvider, GeminiProvider, OpenCodeProvider
+from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY, OPENCODE_API_KEY, PROVIDER
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +45,19 @@ def initialize_llm_provider(model_name: str) -> Any:
         model_name: The name of the model to use
 
     Returns:
-        An initialized LLM provider (either OllamaProvider or GeminiProvider)
+        An initialized LLM provider (either OllamaProvider, GeminiProvider, or OpenCodeProvider)
     """
-    # Default to Ollama provider
+    # Check explicitly set provider first
+    if PROVIDER == ModelProvider.OPENCODE.value or PROVIDER == "opencode":
+        if not OPENCODE_API_KEY:
+            logger.warning("⚠️ OpenCode API key not found. Falling back to Ollama.")
+            return OllamaProvider()
+        else:
+            logger.info(f"🔄 Using OpenCode API provider with model {model_name}")
+            return OpenCodeProvider(api_key=OPENCODE_API_KEY)
+
+    # Otherwise fallback to mapping
     provider = OllamaProvider()
-    # If using Gemini and API key is available, use Gemini provider
     model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
     if model_provider == ModelProvider.GEMINI:
         if not GEMINI_API_KEY:
@@ -57,6 +65,12 @@ def initialize_llm_provider(model_name: str) -> Any:
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.OPENCODE:
+        if not OPENCODE_API_KEY:
+            logger.warning("⚠️ OpenCode API key not found. Falling back to Ollama.")
+        else:
+            logger.info(f"🔄 Using OpenCode API provider with model {model_name}")
+            provider = OpenCodeProvider(api_key=OPENCODE_API_KEY)
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
     return provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    OPENCODE = "opencode"
 
 
 @runtime_checkable
@@ -19,7 +20,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -281,7 +282,7 @@ class OllamaProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -324,7 +325,7 @@ class GeminiProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Google Gemini API."""
         import re
@@ -375,7 +376,7 @@ class GeminiProvider:
                 api_hint = float(match.group(1)) if match else None
 
                 # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
-                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
 
                 # Prefer the API hint when it is shorter than our computed delay
                 delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay
@@ -389,3 +390,57 @@ class GeminiProvider:
                     f"Retrying in {sleep_time}s..."
                 )
                 time.sleep(sleep_time)
+
+
+class OpenCodeProvider:
+    """OpenCode API provider implementation."""
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.base_url = "https://opencode.ai/zen/go/v1"
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Send a chat request to OpenCode API (OpenAI-compatible)."""
+        import requests
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        # Convert roles if needed, though most OpenAI compat APIs accept standard user/assistant/system roles
+        formatted_messages = []
+        for msg in messages:
+            role = msg["role"]
+            # Map standard system/user/assistant roles
+            if role == "model":
+                role = "assistant"
+            formatted_messages.append({"role": role, "content": msg["content"]})
+
+        payload = {
+            "model": model,
+            "messages": formatted_messages,
+        }
+
+        if options:
+            if "temperature" in options:
+                payload["temperature"] = options["temperature"]
+            if "top_p" in options:
+                payload["top_p"] = options["top_p"]
+
+        response = requests.post(
+            f"{self.base_url}/chat/completions",
+            json=payload,
+            headers=headers,
+            timeout=60,
+        )
+        response.raise_for_status()
+        data = response.json()
+        content = data["choices"][0]["message"]["content"]
+        return {"message": {"role": "assistant", "content": content}}

--- a/prompt.py
+++ b/prompt.py
@@ -41,6 +41,13 @@ MODEL_PARAMETERS = {
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # OpenCode models
+    "deepseek-v4-flash": {"temperature": 0.1, "top_p": 0.9},
+    "deepseek-v4-pro": {"temperature": 0.1, "top_p": 0.9},
+    "qwen3.7-max": {"temperature": 0.1, "top_p": 0.9},
+    "qwen3.7-plus": {"temperature": 0.1, "top_p": 0.9},
+    "kimi-k2.7-code": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-5.5": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -61,7 +68,15 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
+    # OpenCode models
+    "deepseek-v4-flash": ModelProvider.OPENCODE,
+    "deepseek-v4-pro": ModelProvider.OPENCODE,
+    "qwen3.7-max": ModelProvider.OPENCODE,
+    "qwen3.7-plus": ModelProvider.OPENCODE,
+    "kimi-k2.7-code": ModelProvider.OPENCODE,
+    "gpt-5.5": ModelProvider.OPENCODE,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+OPENCODE_API_KEY = os.getenv("OPENCODE_API_KEY", "")

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from models import ModelProvider, OpenCodeProvider
+from llm_utils import initialize_llm_provider
+
+
+class TestOpenCodeProvider(unittest.TestCase):
+    def setUp(self):
+        self.api_key = "test_key"
+        self.provider = OpenCodeProvider(self.api_key)
+
+    @patch("requests.post")
+    def test_chat_success(self, mock_post):
+        # Mock successful API response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Test response"}}]
+        }
+        mock_post.return_value = mock_response
+
+        messages = [
+            {"role": "system", "content": "You are an assistant"},
+            {"role": "user", "content": "Hello"},
+            {"role": "model", "content": "Hi"},
+        ]
+
+        response = self.provider.chat(
+            model="deepseek-v4-flash",
+            messages=messages,
+            options={"temperature": 0.5, "top_p": 0.8},
+        )
+
+        # Assert response structure
+        self.assertEqual(
+            response, {"message": {"role": "assistant", "content": "Test response"}}
+        )
+
+        # Verify POST request parameters
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], "https://opencode.ai/zen/go/v1/chat/completions")
+        self.assertEqual(kwargs["headers"]["Authorization"], f"Bearer {self.api_key}")
+
+        # Verify message roles conversion (model -> assistant)
+        payload = kwargs["json"]
+        self.assertEqual(payload["model"], "deepseek-v4-flash")
+        self.assertEqual(payload["temperature"], 0.5)
+        self.assertEqual(payload["top_p"], 0.8)
+        self.assertEqual(payload["messages"][2]["role"], "assistant")
+
+    @patch("requests.post")
+    def test_chat_failure(self, mock_post):
+        # Mock API failure
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("HTTP Error")
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(Exception):
+            self.provider.chat(
+                model="deepseek-v4-flash",
+                messages=[{"role": "user", "content": "Hello"}],
+            )
+
+
+class TestLLMProviderInitialization(unittest.TestCase):
+    @patch("llm_utils.PROVIDER", "opencode")
+    @patch("llm_utils.OPENCODE_API_KEY", "test_key")
+    def test_initialize_opencode_by_provider(self):
+        provider = initialize_llm_provider("some-model")
+        self.assertIsInstance(provider, OpenCodeProvider)
+        self.assertEqual(provider.api_key, "test_key")
+
+    @patch("llm_utils.PROVIDER", "ollama")
+    @patch("llm_utils.OPENCODE_API_KEY", "")
+    @patch(
+        "llm_utils.MODEL_PROVIDER_MAPPING",
+        {"deepseek-v4-flash": ModelProvider.OPENCODE},
+    )
+    def test_initialize_opencode_fallback_without_key(self):
+        # Should fallback to Ollama if no key
+        provider = initialize_llm_provider("deepseek-v4-flash")
+        from models import OllamaProvider
+
+        self.assertIsInstance(provider, OllamaProvider)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Integrates OpenCode AI (`https://opencode.ai`) as a hosted API provider option alongside Ollama and Gemini.

## Motivation

Many developers want to run open-weight models like `deepseek-v4-flash` but lack the local GPU hardware required to run them locally via Ollama. By supporting the OpenCode OpenAI-compatible API endpoint directly, users can process and score resumes with highly performant coding models via a simple API call.

## Changes

| File | What changed |
|---|---|
| `models.py` | Added `OPENCODE = "opencode"` to the `ModelProvider` enum. Implemented the `OpenCodeProvider` class using inline `requests` calls to connect to OpenCode's OpenAI-compatible completions endpoint. |
| `llm_utils.py` | Integrated `OpenCodeProvider` into the `initialize_llm_provider` lifecycle (handling provider-based checks and falling back to Ollama if the key is missing). |
| `prompt.py` | Mapped model parameters and mapped 6 popular OpenCode models (`deepseek-v4-flash`, `deepseek-v4-pro`, `qwen3.7-max`, `qwen3.7-plus`, `kimi-k2.7-code`, and `gpt-5.5`) to `ModelProvider.OPENCODE`. Added retrieval of the `OPENCODE_API_KEY` from the environment. |
| `.env.example` | Documented the new provider and model options, and added the `OPENCODE_API_KEY` placeholder. |
| `tests.py` | Added 4 self-contained unit tests using the standard library `unittest` and `unittest.mock` to verify payload conversion, request formatting, error raising, and provider fallback logic. |

## Testing

Validated the implementation by creating and running the unit test suite inside WSL:
```bash
python -m unittest tests.py
```
**Output:**
```text
Ran 4 tests in 0.223s
OK
```

Closes #296
