### PR TITLE
fix: enforce eval fairness, migrate Gemini to google-genai, harden extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 resume/*.pdf
 run/*.pdf
 test_*.py
+# ...but keep the project's actual test suite under tests/ tracked.
+!tests/test_*.py
 cache/
 resume_evaluations.csv
 greenhouse_resumes/*

--- a/README.md
+++ b/README.md
@@ -143,14 +143,17 @@ $ cp .env.example .env
 | `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
 | `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
 
-Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
+Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has two flags:
 
 ```python
 # config.py
-DEVELOPMENT_MODE = True  # enables caching and CSV export
+DEVELOPMENT_MODE = True            # enables caching and CSV export
+REDACT_PII_FOR_EVALUATION = True   # strip bias-inducing PII before scoring
 ```
 
-You can leave it on during iteration. See the next section for details.
+`DEVELOPMENT_MODE` you can leave on during iteration (see the next section).
+
+`REDACT_PII_FOR_EVALUATION` strips the factors the rubric declares off-limits — name, contact details, location, school name, and GPA — from the text sent to the evaluation LLM, so the score cannot depend on them. The original data is preserved for the CSV export and the recruiter-facing report; only the scorer's input is redacted. Set it to `False` to send the resume unredacted.
 
 ---
 
@@ -262,9 +265,13 @@ What happens:
 ### Gemini
 
 - Set `LLM_PROVIDER=gemini`
-- Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
+- Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.5-flash`
+  (also recognized: `gemini-2.5-pro`, `gemini-2.5-flash-lite`, `gemini-2.0-flash`, `gemini-2.0-flash-lite`)
 - Provide `GEMINI_API_KEY`
-- The wrapper in `models.GeminiProvider` adapts responses to a unified format
+- `models.GeminiProvider` is built on the `google-genai` SDK. It sends the
+  system prompt as Gemini's `system_instruction`, enforces structured output
+  via `response_schema`, retries on rate limits, and adapts the response back
+  to the unified Ollama-style shape the rest of the pipeline expects.
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -4,3 +4,9 @@ Configuration settings for the hiring agent application.
 
 # Global development mode flag
 DEVELOPMENT_MODE = True
+
+# When True, strip bias-inducing PII (name, contact details, location, school
+# name, GPA) from the resume and GitHub data before they reach the evaluation
+# LLM. The original data is preserved for CSV export and recruiter-facing
+# output; only the text sent to the scorer is redacted.
+REDACT_PII_FOR_EVALUATION = True

--- a/evaluator.py
+++ b/evaluator.py
@@ -72,8 +72,10 @@ class ResumeEvaluator:
                 },
             }
 
-            # Add format parameter for structured output
-            kwargs = {"format": EvaluationData.model_json_schema()}
+            # Add format parameter for structured output. Pass the pydantic
+            # class; each provider adapts it (Ollama -> JSON schema dict,
+            # Gemini -> native schema conversion).
+            kwargs = {"format": EvaluationData}
             # Use the appropriate provider to make the API call
             response = self.provider.chat(**chat_params, **kwargs)
 

--- a/models.py
+++ b/models.py
@@ -1,3 +1,6 @@
+import re
+import time
+import random
 from typing import List, Optional, Dict, Tuple, Any, Protocol, runtime_checkable
 from pydantic import BaseModel, Field, field_validator
 from enum import Enum
@@ -19,7 +22,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -217,7 +220,10 @@ class JSONResume(BaseModel):
 
 class CategoryScore(BaseModel):
     score: float = Field(ge=0, description="Score achieved in this category")
-    max: int = Field(gt=0, description="Maximum possible score")
+    # ge=1 (not gt=0) so the JSON schema emits the inclusive `minimum`
+    # keyword; Gemini's Schema type rejects `exclusiveMinimum`. Equivalent for
+    # integers. See tests/test_schema_gemini_compat.py.
+    max: int = Field(ge=1, description="Maximum possible score")
     evidence: str = Field(min_length=1, description="Evidence supporting the score")
 
 
@@ -281,7 +287,7 @@ class OllamaProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -304,88 +310,133 @@ class OllamaProvider:
         if "stream" in kwargs:
             chat_params["stream"] = kwargs["stream"]
 
-        if "format" in kwargs:
-            chat_params["format"] = kwargs["format"]
+        if "format" in kwargs and kwargs["format"] is not None:
+            fmt = kwargs["format"]
+            # The canonical format is a pydantic model class; Ollama wants a
+            # JSON-schema dict. A dict (or "json") is passed through untouched.
+            if isinstance(fmt, type) and issubclass(fmt, BaseModel):
+                fmt = fmt.model_json_schema()
+            chat_params["format"] = fmt
 
         return self.client.chat(**chat_params)
 
 
+def build_gemini_request(
+    messages: List[Dict[str, str]],
+    options: Optional[Dict[str, Any]] = None,
+    kwargs: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Translate the unified chat call into google-genai request pieces.
+
+    Returns a dict with three keys:
+      - ``system_instruction``: the concatenated system message(s), or None.
+        Gemini takes the system prompt as a dedicated field rather than a
+        conversation turn -- the legacy code mislabeled it as a "model" turn,
+        which degraded instruction-following.
+      - ``contents``: the non-system turns, with role "assistant" mapped to
+        Gemini's "model".
+      - ``generation_config``: temperature/top_p plus, when a ``format`` schema
+        is supplied, ``response_mime_type``/``response_schema`` so structured
+        output is enforced the same way Ollama enforces ``format``.
+    """
+    options = options or {}
+    kwargs = kwargs or {}
+
+    system_parts = [
+        m["content"] for m in messages if m.get("role") == "system" and m.get("content")
+    ]
+    system_instruction = "\n\n".join(system_parts) if system_parts else None
+
+    contents = []
+    for msg in messages:
+        role = msg.get("role")
+        if role == "system":
+            continue
+        gemini_role = "model" if role == "assistant" else "user"
+        contents.append({"role": gemini_role, "parts": [{"text": msg["content"]}]})
+
+    generation_config: Dict[str, Any] = {}
+    if "temperature" in options:
+        generation_config["temperature"] = options["temperature"]
+    if "top_p" in options:
+        generation_config["top_p"] = options["top_p"]
+    if kwargs.get("format"):
+        generation_config["response_mime_type"] = "application/json"
+        generation_config["response_schema"] = kwargs["format"]
+
+    return {
+        "system_instruction": system_instruction,
+        "contents": contents,
+        "generation_config": generation_config,
+    }
+
+
 class GeminiProvider:
-    """Google Gemini API provider implementation."""
+    """Google Gemini provider built on the google-genai SDK."""
 
-    def __init__(self, api_key: str):
-        import google.generativeai as genai
+    MAX_RETRIES = 5
+    BASE_DELAY = 10.0  # seconds — base for exponential backoff
+    MAX_DELAY = 120.0  # cap so we never wait more than 2 minutes
 
-        genai.configure(api_key=api_key)
-        self.client = genai
+    def __init__(self, api_key: str, client: Any = None):
+        # ``client`` is injectable for testing; in production we build the real
+        # google-genai client from the API key.
+        if client is not None:
+            self.client = client
+        else:
+            from google import genai
+
+            self.client = genai.Client(api_key=api_key)
 
     def chat(
         self,
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
-        """Send a chat request to Google Gemini API."""
-        import re
-        import time
-        import random
-        from google.api_core.exceptions import ResourceExhausted
+        """Send a chat request to Gemini, returning an Ollama-compatible dict."""
+        from google.genai import types
+        from google.genai import errors
 
-        MAX_RETRIES = 5
-        BASE_DELAY = 10.0  # seconds — base for exponential backoff
-        MAX_DELAY = 120.0  # cap so we never wait more than 2 minutes
-
-        # Map options to Gemini parameters
-        generation_config = {}
-        if options:
-            if "temperature" in options:
-                generation_config["temperature"] = options["temperature"]
-            if "top_p" in options:
-                generation_config["top_p"] = options["top_p"]
-
-        # Create a Gemini model
-        gemini_model = self.client.GenerativeModel(
-            model_name=model, generation_config=generation_config
+        req = build_gemini_request(messages, options, kwargs)
+        config = types.GenerateContentConfig(
+            system_instruction=req["system_instruction"],
+            **req["generation_config"],
         )
 
-        # Convert messages to Gemini format
-        gemini_messages = []
-        for msg in messages:
-            role = "user" if msg["role"] == "user" else "model"
-            gemini_messages.append({"role": role, "parts": [msg["content"]]})
-
-        for attempt in range(MAX_RETRIES):
+        for attempt in range(self.MAX_RETRIES):
             try:
-                # Send the chat request
-                response = gemini_model.generate_content(gemini_messages)
-
-                # Convert Gemini response to Ollama-like format for compatibility
+                response = self.client.models.generate_content(
+                    model=model,
+                    contents=req["contents"],
+                    config=config,
+                )
+                # Normalize to the Ollama-like shape the rest of the code expects.
                 return {"message": {"role": "assistant", "content": response.text}}
 
-            except ResourceExhausted as e:
-                if attempt == MAX_RETRIES - 1:
-                    # All retries exhausted — re-raise the original exception.
-                    # This surfaces unrecoverable quota errors (RPD, TPM, etc.)
-                    # instead of silently failing or returning bad data.
+            except errors.APIError as e:
+                # Only 429 (rate limit / resource exhausted) is retriable; let
+                # everything else surface immediately.
+                if getattr(e, "code", None) != 429 or attempt == self.MAX_RETRIES - 1:
                     raise
 
-                # Parse the API-suggested retry delay from the error message
+                # Parse the API-suggested retry delay from the error message.
                 match = re.search(r"retry[_ ]in\s+([\d.]+)s", str(e), re.IGNORECASE)
                 api_hint = float(match.group(1)) if match else None
 
-                # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
-                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY.
+                exp_delay = min(self.BASE_DELAY * (2**attempt), self.MAX_DELAY)
 
-                # Prefer the API hint when it is shorter than our computed delay
+                # Prefer the API hint when it is shorter than our computed delay.
                 delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay
 
-                # Add ±20% randomized jitter to avoid thundering herd
+                # Add ±20% randomized jitter to avoid thundering herd.
                 sleep_time = round(delay * random.uniform(0.8, 1.2), 2)
 
                 print(
                     f"[GeminiProvider] Rate limit hit "
-                    f"(attempt {attempt + 1}/{MAX_RETRIES}). "
+                    f"(attempt {attempt + 1}/{self.MAX_RETRIES}). "
                     f"Retrying in {sleep_time}s..."
                 )
                 time.sleep(sleep_time)

--- a/pdf.py
+++ b/pdf.py
@@ -100,7 +100,8 @@ class PDFHandler:
 
             kwargs = {}
             if return_model:
-                kwargs["format"] = return_model.model_json_schema()
+                # Pass the pydantic class; the provider adapts it for its SDK.
+                kwargs["format"] = return_model
 
             # Use the appropriate provider to make the API call
             response = self.provider.chat(**chat_params, **kwargs)
@@ -286,17 +287,33 @@ class PDFHandler:
             "meta": None,
         }
 
+        succeeded = []
+        failed = []
         for section_name in sections:
             section_data = self._extract_section_data(text_content, section_name)
 
             if section_data:
                 complete_resume.update(section_data)
+                succeeded.append(section_name)
                 logger.debug(f"✅ Successfully extracted {section_name} section")
             else:
-                logger.error(
-                    f"⚠️ Failed to extract {section_name} section. Aborting extraction to prevent partial/invalid resume data."
+                # A single section failing (flaky JSON from a small model, a
+                # section the resume simply doesn't have, etc.) must not throw
+                # away the sections that did parse. Keep going and record it.
+                failed.append(section_name)
+                logger.warning(
+                    f"⚠️ Failed to extract {section_name} section; continuing with the remaining sections."
                 )
-                return None
+
+        if failed:
+            logger.warning(
+                f"Extraction completed with {len(failed)} failed section(s): "
+                f"{', '.join(failed)}. Succeeded: {', '.join(succeeded) or 'none'}."
+            )
+
+        if not succeeded:
+            logger.error("❌ No sections could be extracted from the resume. Aborting.")
+            return None
 
         try:
             if complete_resume.get("basics") and isinstance(

--- a/prompt.py
+++ b/prompt.py
@@ -39,8 +39,6 @@ MODEL_PARAMETERS = {
     "gemini-2.5-pro": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
-    "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
-    "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -59,8 +57,6 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-flash": ModelProvider.GEMINI,
     "gemini-2.5-flash-lite": ModelProvider.GEMINI,
     "gemini-2.5-pro": ModelProvider.GEMINI,
-    "gemini-3.5-flash": ModelProvider.GEMINI,
-    "gemini-3.1-flash-lite": ModelProvider.GEMINI,
 }
 
 # Get API keys from environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pydantic==2.11.7
 requests==2.32.4
 pymupdf4llm==0.0.27
 Jinja2==3.1.6
-google-generativeai==0.4.0
+google-genai==1.21.0
 python-dotenv==1.0.1
 black==25.9.0
+pytest==8.3.4

--- a/score.py
+++ b/score.py
@@ -15,8 +15,21 @@ from transform import (
     convert_json_resume_to_text,
     convert_github_data_to_text,
     convert_blog_data_to_text,
+    redact_resume_for_evaluation,
+    redact_github_data_for_evaluation,
 )
-from config import DEVELOPMENT_MODE
+from config import DEVELOPMENT_MODE, REDACT_PII_FOR_EVALUATION
+
+# The readable report (and many debug prints) use emoji. On Windows the
+# console / a redirected pipe defaults to a legacy code page (e.g. cp1252)
+# that can't encode them, which otherwise crashes the run after a successful
+# evaluation. Force UTF-8 output where the streams support it.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (ValueError, OSError):
+            pass
 
 logger = logging.getLogger(__name__)
 
@@ -167,12 +180,22 @@ def _evaluate_resume(
     model_params = MODEL_PARAMETERS.get(DEFAULT_MODEL)
     evaluator = ResumeEvaluator(model_name=DEFAULT_MODEL, model_params=model_params)
 
+    # Strip bias-inducing PII before the resume ever reaches the scorer, so the
+    # evaluation cannot depend on name, location, school, or GPA. The original
+    # resume_data/github_data are left untouched for the CSV and display paths.
+    eval_resume = resume_data
+    eval_github_data = github_data
+    if REDACT_PII_FOR_EVALUATION:
+        eval_resume = redact_resume_for_evaluation(resume_data)
+        if github_data:
+            eval_github_data = redact_github_data_for_evaluation(github_data)
+
     # Convert JSON resume data to text
-    resume_text = convert_json_resume_to_text(resume_data)
+    resume_text = convert_json_resume_to_text(eval_resume)
 
     # Add GitHub data if available
-    if github_data:
-        github_text = convert_github_data_to_text(github_data)
+    if eval_github_data:
+        github_text = convert_github_data_to_text(eval_github_data)
         resume_text += github_text
 
     # Add blog data if available

--- a/tests/test_evaluation_wiring.py
+++ b/tests/test_evaluation_wiring.py
@@ -1,0 +1,78 @@
+"""The evaluation orchestration in score._evaluate_resume must feed the
+evaluator REDACTED text when the config flag is on, and raw text when it is
+off. We capture the text handed to the evaluator via a fake provider, so no
+LLM is involved.
+"""
+
+import score
+from models import (
+    JSONResume,
+    Basics,
+    Location,
+    EvaluationData,
+    Scores,
+    CategoryScore,
+    BonusPoints,
+    Deductions,
+)
+
+
+def _dummy_evaluation() -> EvaluationData:
+    cat = CategoryScore(score=1, max=10, evidence="x")
+    return EvaluationData(
+        scores=Scores(
+            open_source=CategoryScore(score=1, max=35, evidence="x"),
+            self_projects=CategoryScore(score=1, max=30, evidence="x"),
+            production=CategoryScore(score=1, max=25, evidence="x"),
+            technical_skills=cat,
+        ),
+        bonus_points=BonusPoints(total=0, breakdown="none"),
+        deductions=Deductions(total=0, reasons="none"),
+        key_strengths=["s"],
+        areas_for_improvement=["a"],
+    )
+
+
+class _CapturingEvaluator:
+    """Stand-in for ResumeEvaluator that records the text it is asked to score."""
+
+    captured_text = None
+
+    def __init__(self, model_name=None, model_params=None):
+        pass
+
+    def evaluate_resume(self, resume_text):
+        _CapturingEvaluator.captured_text = resume_text
+        return _dummy_evaluation()
+
+
+def _resume_with_identity() -> JSONResume:
+    return JSONResume(
+        basics=Basics(
+            name="Jane Q. Candidate",
+            email="jane@example.com",
+            location=Location(city="Austin", region="Texas"),
+        )
+    )
+
+
+def test_evaluation_redacts_identity_when_flag_on(monkeypatch):
+    monkeypatch.setattr(score, "ResumeEvaluator", _CapturingEvaluator)
+    monkeypatch.setattr(score, "REDACT_PII_FOR_EVALUATION", True)
+    _CapturingEvaluator.captured_text = None
+
+    score._evaluate_resume(_resume_with_identity())
+
+    assert _CapturingEvaluator.captured_text is not None
+    assert "Jane Q. Candidate" not in _CapturingEvaluator.captured_text
+    assert "Austin" not in _CapturingEvaluator.captured_text
+
+
+def test_evaluation_keeps_identity_when_flag_off(monkeypatch):
+    monkeypatch.setattr(score, "ResumeEvaluator", _CapturingEvaluator)
+    monkeypatch.setattr(score, "REDACT_PII_FOR_EVALUATION", False)
+    _CapturingEvaluator.captured_text = None
+
+    score._evaluate_resume(_resume_with_identity())
+
+    assert "Jane Q. Candidate" in _CapturingEvaluator.captured_text

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -1,0 +1,146 @@
+"""GeminiProvider migrated to the google-genai SDK (#2 provider parity).
+
+Two real bugs are pinned here:
+  1. The system message must become Gemini's ``system_instruction`` -- NOT be
+     replayed as a "model" turn (the legacy bug).
+  2. The ``format`` kwarg (a JSON schema) must drive structured output via
+     ``response_mime_type`` + ``response_schema``, matching Ollama's behavior.
+
+Request construction is unit-tested through the pure ``build_gemini_request``
+helper; the provider's call contract and rate-limit retry are tested with an
+injected fake client, so no API key or network is involved.
+"""
+
+import pytest
+from google.genai import errors
+
+from models import GeminiProvider, build_gemini_request
+
+
+MESSAGES = [
+    {"role": "system", "content": "You are a strict scorer."},
+    {"role": "user", "content": "Score this resume."},
+]
+
+
+def test_system_message_becomes_system_instruction_not_a_turn():
+    req = build_gemini_request(MESSAGES, {"temperature": 0.1, "top_p": 0.9}, {})
+
+    assert req["system_instruction"] == "You are a strict scorer."
+    # The system text must not leak into the conversation contents.
+    for content in req["contents"]:
+        assert "strict scorer" not in str(content)
+    # Only the non-system turns remain.
+    assert len(req["contents"]) == 1
+
+
+def test_role_mapping_user_and_assistant():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    req = build_gemini_request(messages, {}, {})
+
+    roles = [c["role"] for c in req["contents"]]
+    assert roles == ["user", "model"]
+    assert req["system_instruction"] is None
+    # google-genai requires parts to be Part-shaped dicts ({"text": ...}),
+    # not bare strings -- the live API rejects bare strings inside a role dict.
+    assert req["contents"][0]["parts"] == [{"text": "hi"}]
+    assert req["contents"][1]["parts"] == [{"text": "hello"}]
+
+
+def test_format_kwarg_enables_structured_output():
+    schema = {"type": "object", "properties": {"score": {"type": "integer"}}}
+    req = build_gemini_request(MESSAGES, {}, {"format": schema})
+
+    gen = req["generation_config"]
+    assert gen["response_mime_type"] == "application/json"
+    assert gen["response_schema"] == schema
+
+
+def test_generation_params_mapped_from_options():
+    req = build_gemini_request(MESSAGES, {"temperature": 0.3, "top_p": 0.5}, {})
+
+    gen = req["generation_config"]
+    assert gen["temperature"] == 0.3
+    assert gen["top_p"] == 0.5
+    # Without a format kwarg, no structured-output keys are forced on.
+    assert "response_schema" not in gen
+
+
+class _FakeModels:
+    def __init__(self, text='{"ok": true}'):
+        self._text = text
+        self.calls = []
+
+    def generate_content(self, model, contents, config):
+        self.calls.append({"model": model, "contents": contents, "config": config})
+
+        class _Resp:
+            text = self._text
+
+        return _Resp()
+
+
+class _FakeClient:
+    def __init__(self, text='{"ok": true}'):
+        self.models = _FakeModels(text)
+
+
+def test_chat_returns_ollama_compatible_shape():
+    client = _FakeClient(text='{"score": 5}')
+    provider = GeminiProvider(api_key="unused", client=client)
+
+    result = provider.chat(
+        model="gemini-2.0-flash",
+        messages=MESSAGES,
+        options={"temperature": 0.1, "top_p": 0.9},
+    )
+
+    assert result["message"]["content"] == '{"score": 5}'
+    # The system instruction reached the SDK config, not the contents.
+    config = client.models.calls[0]["config"]
+    assert config.system_instruction == "You are a strict scorer."
+
+
+class _FlakyModels:
+    """Raises a 429 once, then succeeds."""
+
+    def __init__(self):
+        self.attempts = 0
+
+    def generate_content(self, model, contents, config):
+        self.attempts += 1
+        if self.attempts == 1:
+            raise errors.APIError(
+                429,
+                {
+                    "error": {
+                        "message": "Resource exhausted, retry in 1s",
+                        "status": "RESOURCE_EXHAUSTED",
+                    }
+                },
+            )
+
+        class _Resp:
+            text = "recovered"
+
+        return _Resp()
+
+
+class _FlakyClient:
+    def __init__(self):
+        self.models = _FlakyModels()
+
+
+def test_chat_retries_on_rate_limit(monkeypatch):
+    # Don't actually sleep during the backoff.
+    monkeypatch.setattr("models.time.sleep", lambda *_a, **_k: None)
+    client = _FlakyClient()
+    provider = GeminiProvider(api_key="unused", client=client)
+
+    result = provider.chat(model="gemini-2.0-flash", messages=MESSAGES, options={})
+
+    assert result["message"]["content"] == "recovered"
+    assert client.models.attempts == 2

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,10 @@
+"""Guard the model config in prompt.py: every model with tuned parameters must
+also declare a provider (and vice versa). A model present in one dict but not
+the other silently falls back to defaults/Ollama, which is hard to notice.
+"""
+
+from prompt import MODEL_PARAMETERS, MODEL_PROVIDER_MAPPING
+
+
+def test_parameter_and_provider_dicts_cover_the_same_models():
+    assert set(MODEL_PARAMETERS) == set(MODEL_PROVIDER_MAPPING)

--- a/tests/test_provider_format_adaptation.py
+++ b/tests/test_provider_format_adaptation.py
@@ -1,0 +1,58 @@
+"""The canonical structured-output 'format' is a pydantic model CLASS. Each
+provider adapts it to what its SDK wants:
+  - Ollama needs a JSON-schema dict.
+  - Gemini's SDK natively converts a pydantic class (and rejects pydantic's
+    raw JSON-schema dict, e.g. exclusiveMinimum / $ref).
+A plain dict passed as format must still flow through untouched (back-compat).
+"""
+
+from models import OllamaProvider, build_gemini_request, EvaluationData
+
+
+class _FakeOllama:
+    def __init__(self):
+        self.kw = None
+
+    def chat(self, **kw):
+        self.kw = kw
+        return {"message": {"content": "{}"}}
+
+
+def _ollama_with_fake():
+    p = OllamaProvider()
+    p.client = _FakeOllama()
+    return p
+
+
+def test_ollama_converts_pydantic_class_to_json_schema():
+    p = _ollama_with_fake()
+    p.chat(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        options={},
+        format=EvaluationData,
+    )
+    fmt = p.client.kw["format"]
+    assert isinstance(fmt, dict)
+    assert "properties" in fmt  # it's a real JSON schema, not the class
+
+
+def test_ollama_passes_dict_format_through():
+    p = _ollama_with_fake()
+    schema = {"type": "object", "properties": {}}
+    p.chat(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        options={},
+        format=schema,
+    )
+    assert p.client.kw["format"] == schema
+
+
+def test_gemini_request_passes_pydantic_class_as_response_schema():
+    req = build_gemini_request(
+        [{"role": "user", "content": "hi"}], {}, {"format": EvaluationData}
+    )
+    gen = req["generation_config"]
+    assert gen["response_schema"] is EvaluationData
+    assert gen["response_mime_type"] == "application/json"

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,142 @@
+"""Tests for PII redaction applied before the evaluation LLM call (#1 fairness).
+
+The evaluator must never receive the factors the rubric declares off-limits:
+name, contact details, location, school name, and GPA. These tests pin that
+the redaction blanks exactly those fields, preserves all technical signal, and
+never mutates the caller's original resume_data (which the CSV/recruiter still
+needs intact).
+"""
+
+from models import (
+    JSONResume,
+    Basics,
+    Location,
+    Profile,
+    Work,
+    Education,
+    Skill,
+    Project,
+)
+from transform import (
+    redact_resume_for_evaluation,
+    redact_github_data_for_evaluation,
+    convert_json_resume_to_text,
+    convert_github_data_to_text,
+)
+
+
+def _sample_resume() -> JSONResume:
+    return JSONResume(
+        basics=Basics(
+            name="Jane Q. Candidate",
+            email="jane@example.com",
+            phone="+1-555-0100",
+            url="https://janecandidate.dev",
+            summary="Backend engineer who likes distributed systems.",
+            location=Location(city="Austin", region="Texas", countryCode="US"),
+            profiles=[
+                Profile(
+                    network="GitHub", username="janeqc", url="https://github.com/janeqc"
+                ),
+                Profile(
+                    network="LinkedIn",
+                    username="janeqc",
+                    url="https://linkedin.com/in/janeqc",
+                ),
+            ],
+        ),
+        work=[
+            Work(
+                name="Acme Corp", position="SWE Intern", summary="Built a rate limiter."
+            )
+        ],
+        education=[
+            Education(
+                institution="Prestige University",
+                area="Computer Science",
+                studyType="B.S.",
+                score="3.9 GPA",
+            )
+        ],
+        skills=[Skill(name="Python", keywords=["asyncio", "pytest"])],
+        projects=[
+            Project(name="DistKV", description="A toy distributed key-value store.")
+        ],
+    )
+
+
+def test_redaction_blanks_forbidden_fields():
+    redacted = redact_resume_for_evaluation(_sample_resume())
+
+    assert redacted.basics.name in (None, "")
+    assert redacted.basics.email in (None, "")
+    assert redacted.basics.phone in (None, "")
+    assert redacted.basics.location is None
+    assert redacted.education[0].institution in (None, "")
+    assert redacted.education[0].score in (None, "")
+
+
+def test_redaction_preserves_technical_signal():
+    redacted = redact_resume_for_evaluation(_sample_resume())
+
+    # Education: degree subject and type are signal, not demographics.
+    assert redacted.education[0].area == "Computer Science"
+    assert redacted.education[0].studyType == "B.S."
+    # Skills, work, projects, and summary carry the actual evaluation signal.
+    assert redacted.skills[0].name == "Python"
+    assert redacted.work[0].name == "Acme Corp"
+    assert redacted.work[0].summary == "Built a rate limiter."
+    assert redacted.projects[0].name == "DistKV"
+    assert redacted.basics.summary == "Backend engineer who likes distributed systems."
+    # Professional links remain (needed for GitHub enrichment + bonus scoring).
+    assert redacted.basics.profiles is not None
+
+
+def test_redaction_does_not_mutate_original():
+    original = _sample_resume()
+    redact_resume_for_evaluation(original)
+
+    assert original.basics.name == "Jane Q. Candidate"
+    assert original.basics.location is not None
+    assert original.education[0].institution == "Prestige University"
+
+
+def test_redacted_text_excludes_identity_keeps_signal():
+    redacted = redact_resume_for_evaluation(_sample_resume())
+    text = convert_json_resume_to_text(redacted)
+
+    assert "Jane Q. Candidate" not in text
+    assert "jane@example.com" not in text
+    assert "Austin" not in text
+    assert "Prestige University" not in text
+    assert "3.9 GPA" not in text
+    # Signal survives.
+    assert "Python" in text
+    assert "DistKV" in text
+
+
+def test_github_redaction_blanks_name_keeps_repo_signal():
+    github_data = {
+        "profile": {
+            "username": "janeqc",
+            "name": "Jane Q. Candidate",
+            "location": "Austin, TX",
+            "company": "Acme Corp",
+            "public_repos": 12,
+            "followers": 30,
+        },
+        "projects": [
+            {"name": "DistKV", "github_url": "https://github.com/janeqc/distkv"}
+        ],
+        "total_projects": 1,
+    }
+
+    redacted = redact_github_data_for_evaluation(github_data)
+    text = convert_github_data_to_text(redacted)
+
+    assert "Jane Q. Candidate" not in text
+    # Username is the lookup key + not demographic; repo signal must survive.
+    assert redacted["profile"]["username"] == "janeqc"
+    assert "DistKV" in text
+    # Original dict untouched.
+    assert github_data["profile"]["name"] == "Jane Q. Candidate"

--- a/tests/test_schema_gemini_compat.py
+++ b/tests/test_schema_gemini_compat.py
@@ -1,0 +1,15 @@
+"""Gemini's Schema type rejects some JSON-schema keywords that pydantic emits
+(notably exclusiveMinimum/exclusiveMaximum from Field(gt=...)/Field(lt=...)),
+which caused the live structured-output call to fail. Keep the response models
+to the subset Gemini accepts: inclusive bounds only.
+"""
+
+import json
+
+from models import EvaluationData
+
+
+def test_response_model_avoids_unsupported_schema_keywords():
+    schema_text = json.dumps(EvaluationData.model_json_schema())
+    assert "exclusiveMinimum" not in schema_text
+    assert "exclusiveMaximum" not in schema_text

--- a/tests/test_section_extraction_robustness.py
+++ b/tests/test_section_extraction_robustness.py
@@ -1,0 +1,47 @@
+"""#4 robustness: one section failing to parse must not discard the entire
+resume. We keep every section that parsed and only give up when nothing
+usable was extracted. The LLM is stubbed out via _extract_section_data, so no
+model is involved.
+"""
+
+from pdf import PDFHandler
+
+
+def _make_handler():
+    return PDFHandler()
+
+
+def test_partial_section_failure_keeps_good_sections(monkeypatch):
+    handler = _make_handler()
+
+    # education and projects "fail" (None); the rest parse fine.
+    section_results = {
+        "basics": {"basics": {"name": "X"}},
+        "work": {"work": [{"name": "Acme", "position": "SWE Intern"}]},
+        "education": None,
+        "skills": {"skills": [{"name": "Python"}]},
+        "projects": None,
+        "awards": {"awards": []},
+    }
+
+    def fake_extract(text_content, section_name, return_model=None):
+        return section_results[section_name]
+
+    monkeypatch.setattr(handler, "_extract_section_data", fake_extract)
+
+    result = handler._extract_all_sections_separately("resume text")
+
+    assert result is not None
+    assert result.basics is not None and result.basics.name == "X"
+    assert result.work and result.work[0].name == "Acme"
+    assert result.skills and result.skills[0].name == "Python"
+    # Failed sections are simply absent, not fatal.
+    assert result.education is None
+    assert result.projects is None
+
+
+def test_all_sections_failing_returns_none(monkeypatch):
+    handler = _make_handler()
+    monkeypatch.setattr(handler, "_extract_section_data", lambda *a, **k: None)
+
+    assert handler._extract_all_sections_separately("resume text") is None

--- a/transform.py
+++ b/transform.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Optional
+import copy
 import pdb
 from models import JSONResume
 
@@ -739,6 +740,57 @@ def transform_evaluation_response(
         csv_row["areas_for_improvement"] = ""
 
     return csv_row
+
+
+# Factors the evaluation rubric declares off-limits (see
+# prompts/templates/resume_evaluation_criteria.jinja). We strip them
+# structurally before the resume text ever reaches the evaluator LLM, rather
+# than relying on the prompt to ask the model to ignore data it can still see.
+# Professional links (basics.url, profiles) are intentionally preserved: they
+# are not demographic, they drive the portfolio/LinkedIn bonus points, and the
+# GitHub username is required for repository enrichment.
+
+
+def redact_resume_for_evaluation(resume_data: JSONResume) -> JSONResume:
+    """Return a deep copy of ``resume_data`` with bias-inducing PII removed.
+
+    Blanks name, contact details, and location from ``basics``, and the
+    institution name and GPA/score from every education entry. The caller's
+    original object is never mutated, so the CSV export and recruiter-facing
+    output still see the candidate's identity intact.
+    """
+    redacted = copy.deepcopy(resume_data)
+
+    if redacted.basics:
+        redacted.basics.name = None
+        redacted.basics.email = None
+        redacted.basics.phone = None
+        redacted.basics.location = None
+
+    if redacted.education:
+        for edu in redacted.education:
+            edu.institution = None
+            edu.score = None
+
+    return redacted
+
+
+def redact_github_data_for_evaluation(github_data: dict) -> dict:
+    """Return a deep copy of the GitHub data dict with profile PII removed.
+
+    Blanks the display name, location, and company from the profile while
+    keeping the username (the lookup key, not demographic) and all repository
+    signal that the open-source/self-project scoring depends on.
+    """
+    redacted = copy.deepcopy(github_data)
+
+    profile = redacted.get("profile")
+    if isinstance(profile, dict):
+        for field in ("name", "location", "company"):
+            if field in profile:
+                profile[field] = None
+
+    return redacted
 
 
 def convert_json_resume_to_text(resume_data: JSONResume) -> str:


### PR DESCRIPTION
## Summary

Three substantive fixes to the resume scoring pipeline, plus the bugs surfaced while validating them against the live Gemini API. Every change is covered by new tests under `tests/` (run with `pytest`).

### 1. Enforce evaluation fairness structurally
The rubric forbids scoring on name, school, GPA, and location, but the evaluator was still *given* those fields and merely asked to ignore them. Now PII (name, contact details, location, school name, GPA) is stripped from the resume and GitHub data **before** they reach the evaluation LLM, so the score cannot depend on them. The original data is preserved for the CSV export and recruiter-facing report. Gated by a new `REDACT_PII_FOR_EVALUATION` flag in `config.py` (default on).

### 2. Migrate Gemini to the `google-genai` SDK (provider parity)
- Replaced the deprecated `google-generativeai==0.4.0` with `google-genai`.
- The system prompt now becomes Gemini's `system_instruction` (it was previously replayed as a `"model"` turn, degrading instruction-following).
- Structured output is enforced via `response_schema` (the `format` schema was silently dropped for Gemini, so only Ollama got schema enforcement).
- The canonical `format` is now a pydantic class; each provider adapts it (Ollama -> JSON schema dict, Gemini -> native conversion).
- Fixed the message `parts` shape and changed `CategoryScore.max` from `gt=0` to `ge=1` so the emitted schema avoids `exclusiveMinimum`, which Gemini's `Schema` type rejects.

### 3. Harden section extraction
- A single section failing to parse no longer discards the entire resume; the sections that parsed are kept, and extraction only aborts if none succeed.
- Force UTF-8 on stdout/stderr so the emoji report doesn't crash on Windows (cp1252) after a successful evaluation.

### Cleanup
- Removed non-existent Gemini model names (`gemini-3.5-flash`, `gemini-3.1-flash-lite`) from `prompt.py`; added a guard test against param/provider dict drift.
- Stopped `.gitignore`'s blanket `test_*.py` rule from excluding the project's own test suite.
- Updated the README (google-genai provider details, redaction flag) and `requirements.txt`.

## Testing
- 20 new unit tests pass (LLM-free, via mocked providers / injected stubs).
- Verified end-to-end against the live Gemini API (`gemini-2.5-flash`): full PDF -> extraction -> structured evaluation pipeline completes and produces a valid scored report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)