### PR TITLE
feat: add Anthropic Claude provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,15 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "anthropic"
 LLM_PROVIDER=ollama
 
 # Default model to use
-# For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
-# For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For Ollama:    "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
+# For Gemini:    "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For Anthropic: "claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5-20251001"
 DEFAULT_MODEL=gemma3:4b
 
-# Google Gemini API Key (required if using Gemini provider)
+# Google Gemini API Key (required if using the gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# Anthropic Claude API Key (required if using the anthropic provider)
+ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a lo
   - **Ollama** for local models
     Install from the [official site](https://ollama.com/), then run `ollama serve`.
   - **Google Gemini** if you have an API key, get it from [here](https://aistudio.google.com/api-keys).
+  - **Anthropic Claude** if you have an API key, get it from [here](https://console.anthropic.com/settings/keys).
 
 ### Quick setup with pip
 
@@ -136,12 +137,13 @@ $ cp .env.example .env
 
 **Environment variables**
 
-| Variable         | Values                                      | Description                                                            |
-| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
-| `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
-| `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
+| Variable            | Values                                          | Description                                                            |
+| ------------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
+| `LLM_PROVIDER`      | `ollama`, `gemini`, or `anthropic`              | Chooses provider. Defaults to Ollama.                                  |
+| `DEFAULT_MODEL`     | for example `gemma3:4b` or `claude-sonnet-4-6`  | Model name passed to the provider.                                     |
+| `GEMINI_API_KEY`    | string                                          | Required when `LLM_PROVIDER=gemini`.                                   |
+| `ANTHROPIC_API_KEY` | string                                          | Required when `LLM_PROVIDER=anthropic`.                                |
+| `GITHUB_TOKEN`      | optional                                        | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
 
@@ -265,6 +267,16 @@ What happens:
 - Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
+
+### Anthropic
+
+- Set `LLM_PROVIDER=anthropic`
+- Set `DEFAULT_MODEL` to a supported Claude model, for example `claude-sonnet-4-6`
+- Provide `ANTHROPIC_API_KEY`
+- The wrapper in `models.AnthropicProvider` calls the Messages API, lifts any
+  `system` role out of the messages list (Anthropic takes it as a top-level
+  argument), and adapts the response to the same unified format. It retries on
+  rate-limit/overload errors (HTTP 429/5xx) with exponential backoff and jitter.
 
 ---
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,8 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import ModelProvider, OllamaProvider, GeminiProvider, AnthropicProvider
+from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY, ANTHROPIC_API_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ def initialize_llm_provider(model_name: str) -> Any:
     """
     # Default to Ollama provider
     provider = OllamaProvider()
-    # If using Gemini and API key is available, use Gemini provider
+    # If using a hosted provider and its API key is available, use it.
     model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
     if model_provider == ModelProvider.GEMINI:
         if not GEMINI_API_KEY:
@@ -57,6 +57,14 @@ def initialize_llm_provider(model_name: str) -> Any:
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.ANTHROPIC:
+        if not ANTHROPIC_API_KEY:
+            logger.warning("⚠️ Anthropic API key not found. Falling back to Ollama.")
+        else:
+            logger.info(
+                f"🔄 Using Anthropic Claude API provider with model {model_name}"
+            )
+            provider = AnthropicProvider(api_key=ANTHROPIC_API_KEY)
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
     return provider

--- a/models.py
+++ b/models.py
@@ -419,12 +419,15 @@ class AnthropicProvider:
         # Anthropic requires an explicit max_tokens; allow override via options.
         max_tokens = 16384
 
-        # Map options to Anthropic generation parameters.
+        # Map options to Anthropic generation parameters. Note: Anthropic
+        # models reject `temperature` and `top_p` together ("Please use only
+        # one"), so prefer temperature and only fall back to top_p when
+        # temperature is not provided.
         params = {}
         if options:
             if "temperature" in options:
                 params["temperature"] = options["temperature"]
-            if "top_p" in options:
+            elif "top_p" in options:
                 params["top_p"] = options["top_p"]
             if "max_tokens" in options:
                 max_tokens = options["max_tokens"]

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    ANTHROPIC = "anthropic"
 
 
 @runtime_checkable
@@ -19,7 +20,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -281,7 +282,7 @@ class OllamaProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -324,7 +325,7 @@ class GeminiProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Google Gemini API."""
         import re
@@ -375,7 +376,7 @@ class GeminiProvider:
                 api_hint = float(match.group(1)) if match else None
 
                 # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
-                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
 
                 # Prefer the API hint when it is shorter than our computed delay
                 delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay
@@ -385,6 +386,102 @@ class GeminiProvider:
 
                 print(
                     f"[GeminiProvider] Rate limit hit "
+                    f"(attempt {attempt + 1}/{MAX_RETRIES}). "
+                    f"Retrying in {sleep_time}s..."
+                )
+                time.sleep(sleep_time)
+
+
+class AnthropicProvider:
+    """Anthropic Claude API provider implementation."""
+
+    def __init__(self, api_key: str):
+        import anthropic
+
+        self.client = anthropic.Anthropic(api_key=api_key)
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Send a chat request to the Anthropic Messages API."""
+        import time
+        import random
+        import anthropic
+
+        MAX_RETRIES = 5
+        BASE_DELAY = 5.0  # seconds — base for exponential backoff
+        MAX_DELAY = 60.0  # cap so we never wait more than a minute
+
+        # Anthropic requires an explicit max_tokens; allow override via options.
+        max_tokens = 16384
+
+        # Map options to Anthropic generation parameters.
+        params = {}
+        if options:
+            if "temperature" in options:
+                params["temperature"] = options["temperature"]
+            if "top_p" in options:
+                params["top_p"] = options["top_p"]
+            if "max_tokens" in options:
+                max_tokens = options["max_tokens"]
+
+        # Anthropic takes the system prompt as a top-level argument rather than
+        # as a message, and only accepts "user"/"assistant" roles. Pull any
+        # system-role messages out and concatenate them.
+        system_parts = []
+        chat_messages = []
+        for msg in messages:
+            role = msg.get("role")
+            content = msg.get("content", "")
+            if role == "system":
+                system_parts.append(content)
+            else:
+                anthropic_role = "user" if role == "user" else "assistant"
+                chat_messages.append({"role": anthropic_role, "content": content})
+
+        # The messages list must be non-empty.
+        if not chat_messages:
+            chat_messages = [{"role": "user", "content": ""}]
+
+        if system_parts:
+            params["system"] = "\n\n".join(system_parts)
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                response = self.client.messages.create(
+                    model=model,
+                    max_tokens=max_tokens,
+                    messages=chat_messages,
+                    **params,
+                )
+
+                # Concatenate all text blocks and adapt to the Ollama-like
+                # response shape the rest of the codebase expects.
+                text = "".join(
+                    block.text
+                    for block in response.content
+                    if getattr(block, "type", None) == "text"
+                )
+                return {"message": {"role": "assistant", "content": text}}
+
+            except anthropic.APIStatusError as e:
+                status = getattr(e, "status_code", None)
+                retryable = status in (429, 500, 502, 503, 529)
+                if not retryable or attempt == MAX_RETRIES - 1:
+                    # Non-retryable error or retries exhausted — surface it.
+                    raise
+
+                # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY,
+                # with ±20% randomized jitter to avoid thundering herd.
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
+                sleep_time = round(exp_delay * random.uniform(0.8, 1.2), 2)
+
+                print(
+                    f"[AnthropicProvider] {type(e).__name__} (status {status}) "
                     f"(attempt {attempt + 1}/{MAX_RETRIES}). "
                     f"Retrying in {sleep_time}s..."
                 )

--- a/prompt.py
+++ b/prompt.py
@@ -41,6 +41,10 @@ MODEL_PARAMETERS = {
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # Anthropic Claude models
+    "claude-opus-4-8": {"temperature": 0.1, "top_p": 0.9},
+    "claude-sonnet-4-6": {"temperature": 0.1, "top_p": 0.9},
+    "claude-haiku-4-5-20251001": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -61,7 +65,12 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
+    # Anthropic Claude models
+    "claude-opus-4-8": ModelProvider.ANTHROPIC,
+    "claude-sonnet-4-6": ModelProvider.ANTHROPIC,
+    "claude-haiku-4-5-20251001": ModelProvider.ANTHROPIC,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ requests==2.32.4
 pymupdf4llm==0.0.27
 Jinja2==3.1.6
 google-generativeai==0.4.0
+anthropic==0.113.0
 python-dotenv==1.0.1
 black==25.9.0


### PR DESCRIPTION
## Summary

Adds an `AnthropicProvider` so the resume pipeline can run on Claude models, alongside the existing Ollama and Gemini backends. Set `LLM_PROVIDER=anthropic` and `DEFAULT_MODEL=claude-sonnet-4-6` (or another `claude-*` model) plus `ANTHROPIC_API_KEY` to use it.

## Changes

- **`models.py`** — `AnthropicProvider.chat()` calls the Messages API. It lifts any `system`-role message out of the messages list into Anthropic's top-level `system` argument (Anthropic doesn't accept a `system` role inside the messages array), maps `temperature` / `top_p` / `max_tokens`, and adapts the reply back to the same `{"message": {"role", "content"}}` shape the rest of the codebase consumes. Retries on HTTP 429/5xx (rate limit / overload) with exponential backoff + jitter, mirroring the existing Gemini provider.
- **`prompt.py`** — registers `claude-*` models in `MODEL_PROVIDER_MAPPING` and `MODEL_PARAMETERS`, and reads `ANTHROPIC_API_KEY` from the environment.
- **`llm_utils.py`** — initializes `AnthropicProvider` when `LLM_PROVIDER=anthropic`, falling back to Ollama if the key is missing (same pattern as Gemini).
- **`requirements.txt`** — adds the `anthropic` SDK.
- **`.env.example` / `README.md`** — document the new provider, its env vars, and supported model names.

## Design notes

Kept the change provider-agnostic and consistent with the existing backends: same `chat()` signature, same unified return shape, same fall-back-to-Ollama behavior, and the same retry strategy as the Gemini provider. No changes to prompts or scoring logic.

## Testing

- Verified the modules import and that `claude-*` model names resolve to the Anthropic provider via `MODEL_PROVIDER_MAPPING`.
- Ran the full `score.py` pipeline end to end (PDF extraction → GitHub enrichment → evaluation) on a real resume to confirm the new wiring and fallback path don't regress the existing flow.
- `black` clean; `python -m py_compile` clean.

> Note: the structure mirrors the Gemini provider, but I have not exercised the live Anthropic API call within this PR. Maintainers with a key — please sanity-check a real request; happy to iterate on anything.
