### PR TITLE
fix(eval): don't penalize backend projects for missing a live demo (#271)

### DIFF
--- a/prompts/templates/resume_evaluation_criteria.jinja
+++ b/prompts/templates/resume_evaluation_criteria.jinja
@@ -81,6 +81,7 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 - **NO LINKS**: Projects without URLs, GitHub links, or live demos should receive 30-50% lower scores
 - **INACTIVE LINKS**: Projects with broken links should receive 20-30% lower scores
 - **LIVE DEMO BONUS**: Projects with working live demos should receive 10-20% higher scores
+- **BACKEND/INFRASTRUCTURE EXEMPTION**: The live-demo expectation applies ONLY to projects where a user interface is a core deliverable (e.g., web apps, mobile apps, UI/frontend projects). Backend, infrastructure, cloud, data, library, or CLI projects (e.g., REST APIs, Kafka, Redis, Docker, AWS services, ETL pipelines, CLI tools) must NOT be penalized for lacking a live demo. Evaluate these on implementation quality, architecture, documentation, and tests instead, and treat a public GitHub repository as sufficient project evidence (the LIVE DEMO BONUS may still apply if a hosted demo exists, but its absence is not a penalty).
 
 ### Production (0-25 points)
 - Analyze the 'work' and 'volunteer' sections for real-world, internship, or production experience
@@ -133,8 +134,9 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 
 **For Projects Without Links:**
 - -3 to -5 points for each project without any GitHub link, live demo, or active URL
-- -2 to -3 points for each project with only GitHub link but no live demo
+- (UI/frontend projects only) -2 to -3 points for each user-facing project with only a GitHub link but no live demo
 - -1 to -2 points for each project with broken or inactive links
+- **Do NOT** apply a "no live demo" deduction to backend, infrastructure, cloud, data, library, or CLI projects; a public GitHub repository is sufficient evidence for these, and they should be judged on code quality, architecture, documentation, and tests.
 
 **CRITICAL ENFORCEMENT:**
 - When GitHub data shows all projects are 'self_project' type, apply 3-5 point deductions for lack of true open source contributions


### PR DESCRIPTION
## Summary

Fixes #271. The evaluation rubric lowers scores and applies deductions for projects without a live demo. That's appropriate for UI/frontend work, but it unfairly penalizes **backend, infrastructure, cloud, data, library, and CLI projects** (REST APIs, Kafka, Redis, Docker, AWS services, ETL pipelines, CLI tools), which are properly judged by their source code, architecture, documentation, and tests — not a hosted demo.

## Change

Edited `prompts/templates/resume_evaluation_criteria.jinja` (declarative, provider-agnostic — no code changes):

- **Project link requirements:** added a *Backend/Infrastructure Exemption* clause scoping the live-demo expectation to projects where a UI is a core deliverable. For backend/infra/CLI projects, a public GitHub repo counts as sufficient evidence; the live-demo *bonus* still applies if a demo exists, but its absence is no longer a penalty.
- **Deductions:** scoped the "only a GitHub link, no live demo" deduction to user-facing/frontend projects, and added an explicit rule not to apply it to backend/infra/library/CLI projects.

## Why this approach

Keeps the scoring fix in the prompt layer (per CONTRIBUTING: "keep prompts declarative and provider-agnostic"), so it works identically across the Ollama/Gemini backends with no logic changes. It mirrors the maintainer's suggestion in the issue: judge UI projects by demos, and backend projects by implementation quality.

## Testing

Prompt-only change; the template still renders (the trailing `{{ text_content }}` injection is unchanged). Behavior is exercised through the normal `score.py` evaluation path.
