### PR TITLE
fix: normalize deductions total to handle negative values from LLMs

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -82,6 +82,11 @@ class ResumeEvaluator:
             logger.error(f"🔤 Prompt response: {response_text}")
 
             evaluation_dict = json.loads(response_text)
+
+            # Normalize deductions total to positive value (some LLMs return negative)
+            if "deductions" in evaluation_dict and "total" in evaluation_dict["deductions"]:
+                evaluation_dict["deductions"]["total"] = abs(evaluation_dict["deductions"]["total"])
+
             evaluation_data = EvaluationData(**evaluation_dict)
 
             return evaluation_data


### PR DESCRIPTION
Smaller LLMs (e.g., `qwen3.5:4b`) sometimes return `deductions.total` as a negative value (e.g., `-4`), which is semantically correct but violates the Pydantic `ge=0` constraint on the `Deductions` model. This causes a `ValidationError` crash during resume evaluation.

### Changes
- **`evaluator.py`**: Added `abs()` normalization on `deductions.total` after parsing the LLM JSON response and before Pydantic validation.

### Why this approach
- The fix is applied at the parsing boundary (between raw LLM output and validated data), which is the right place to handle LLM output inconsistencies.
- Using `abs()` preserves the intended magnitude regardless of sign convention.
- The `Deductions` model constraint (`ge=0`) is kept as-is, maintaining strict validation for any other callers.
- No prompt changes needed — this is more robust than relying on the LLM to follow sign conventions.

### Testing
Tested with `qwen3.5:4b` on multiple resumes. The evaluation now completes successfully when the LLM returns negative deduction values.
