### PR TITLE
fix: normalize deductions.total to handle negative values from LLMs

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -82,6 +82,11 @@ class ResumeEvaluator:
             logger.error(f"🔤 Prompt response: {response_text}")
 
             evaluation_dict = json.loads(response_text)
+
+            # Normalize deductions total to positive value (some LLMs return negative)
+            if "deductions" in evaluation_dict and "total" in evaluation_dict["deductions"]:
+                evaluation_dict["deductions"]["total"] = abs(evaluation_dict["deductions"]["total"])
+
             evaluation_data = EvaluationData(**evaluation_dict)
 
             return evaluation_data


### PR DESCRIPTION

Fixes the `ValidationError` crash that occurs when smaller LLMs (e.g., `qwen3.5:4b`) return `deductions.total` as a negative value.

### Problem

The [`Deductions`](https://github.com/interviewstreet/hiring-agent/blob/4db86554e622f4fb8e653565bc99fb7df2f6ef93/models.py#L236-L241) model enforces `total >= 0`, but smaller LLMs sometimes return the value as negative (e.g., `-4` instead of `4`), causing a `ValidationError` that crashes resume evaluation.

### Solution

Added `abs()` normalization on `deductions.total` in `evaluator.py` after parsing the LLM JSON response and before Pydantic validation:

```python
# Normalize deductions total to positive value (some LLMs return negative)
if "deductions" in evaluation_dict and "total" in evaluation_dict["deductions"]:
    evaluation_dict["deductions"]["total"] = abs(evaluation_dict["deductions"]["total"])
```

### Why this approach

- **Right boundary**: The fix is applied at the LLM output parsing layer — the correct place to handle LLM response inconsistencies.
- **Robust**: `abs()` handles both positive and negative values correctly without relying on the LLM to follow sign conventions.
- **Non-breaking**: The `Deductions` model constraint (`ge=0`) is preserved, maintaining strict validation for other callers.
- **No prompt changes**: More reliable than modifying prompts to enforce sign conventions on smaller models.

### Files Changed

| File | Change |
|------|--------|
| `evaluator.py` | Added `abs()` normalization on `deductions.total` before Pydantic validation |

### Testing

- Tested with `qwen3.5:4b` on multiple resumes that previously triggered the crash
- Evaluation now completes successfully when the LLM returns negative deduction values
- Positive deduction values continue to work as before (no regression)
