### PR TITLE
feat: add Z.AI (GLM) provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Overview
 
-Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use Google Gemini.
+Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama, use Google Gemini, or use Z.AI (GLM) for a free hosted option.
 
 ---
 
@@ -90,6 +90,7 @@ Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a lo
   - **Ollama** for local models
     Install from the [official site](https://ollama.com/), then run `ollama serve`.
   - **Google Gemini** if you have an API key, get it from [here](https://aistudio.google.com/api-keys).
+  - **Z.AI (GLM)** for free hosted models (no GPU needed), get an API key from [here](https://z.ai/chat).
 
 ### Quick setup with pip
 
@@ -136,12 +137,13 @@ $ cp .env.example .env
 
 **Environment variables**
 
-| Variable         | Values                                      | Description                                                            |
-| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
-| `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
-| `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
+| Variable         | Values                                                | Description                                                            |
+| ---------------- | ----------------------------------------------------- | ---------------------------------------------------------------------- |
+| `LLM_PROVIDER`   | `ollama`, `gemini`, or `zai`                          | Chooses provider. Defaults to Ollama.                                  |
+| `DEFAULT_MODEL`  | e.g. `gemma3:4b`, `gemini-2.5-pro`, `glm-4.5-flash`  | Model name passed to the provider.                                     |
+| `GEMINI_API_KEY` | string                                                | Required when `LLM_PROVIDER=gemini`.                                   |
+| `ZAI_API_KEY`    | string                                                | Required when `LLM_PROVIDER=zai`.                                      |
+| `GITHUB_TOKEN`   | optional                                              | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
 
@@ -266,6 +268,14 @@ What happens:
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
 
+### Z.AI (GLM)
+
+- Set `LLM_PROVIDER=zai`
+- Set `DEFAULT_MODEL` to a supported GLM model, for example `glm-4.5-flash` or `glm-4.7-flash`
+- Provide `ZAI_API_KEY` — get one free (no credit card) at [z.ai](https://z.ai/chat)
+- The wrapper in `models.ZAIProvider` uses the OpenAI-compatible endpoint at `https://api.z.ai/api/paas/v4/`
+- Free tier models: `glm-4.5-flash`, `glm-4.7-flash` (rate limited, 1 concurrent request)
+
 ---
 
 ## Contributing
@@ -277,7 +287,6 @@ Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed guidelines on 
 - Add or adjust unit-free smoke tests that call each stage with minimal inputs.
 
 ---
-
 
 ## License
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions for LLM providers.
 """
+
 import logging
 from typing import Any
 from models import ModelProvider, OllamaProvider, GeminiProvider, ZAIProvider
@@ -8,18 +9,20 @@ from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY, ZAI_API_KEY
 
 logger = logging.getLogger(__name__)
 
+
 def extract_json_from_response(response_text: str) -> str:
     response_text = response_text.strip()
     if "<think>" in response_text:
         think_start = response_text.find("<think>")
         think_end = response_text.find("</think>")
         if think_start != -1 and think_end != -1:
-            response_text = response_text[:think_start] + response_text[think_end + 8:]
+            response_text = response_text[:think_start] + response_text[think_end + 8 :]
     if response_text.startswith("```json"):
         response_text = response_text[7:]
     if response_text.endswith("```"):
         response_text = response_text[:-3]
     return response_text
+
 
 def initialize_llm_provider(model_name: str) -> Any:
     provider = OllamaProvider()

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -1,62 +1,43 @@
 """
 Utility functions for LLM providers.
 """
-
 import logging
-from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from typing import Any
+from models import ModelProvider, OllamaProvider, GeminiProvider, ZAIProvider
+from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY, ZAI_API_KEY
 
 logger = logging.getLogger(__name__)
 
-
 def extract_json_from_response(response_text: str) -> str:
-    """
-    Extract JSON content from markdown code blocks.
-
-    Args:
-        response_text: Text that may contain JSON wrapped in markdown code blocks
-
-    Returns:
-        Text with markdown code block syntax removed
-    """
-
     response_text = response_text.strip()
     if "<think>" in response_text:
         think_start = response_text.find("<think>")
         think_end = response_text.find("</think>")
         if think_start != -1 and think_end != -1:
-            response_text = response_text[:think_start] + response_text[think_end + 8 :]
-
-    # Remove leading ```json if present
+            response_text = response_text[:think_start] + response_text[think_end + 8:]
     if response_text.startswith("```json"):
         response_text = response_text[7:]
-    # Remove trailing ``` if present
     if response_text.endswith("```"):
         response_text = response_text[:-3]
     return response_text
 
-
 def initialize_llm_provider(model_name: str) -> Any:
-    """
-    Initialize the appropriate LLM provider based on the model name.
-
-    Args:
-        model_name: The name of the model to use
-
-    Returns:
-        An initialized LLM provider (either OllamaProvider or GeminiProvider)
-    """
-    # Default to Ollama provider
     provider = OllamaProvider()
-    # If using Gemini and API key is available, use Gemini provider
     model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
+
     if model_provider == ModelProvider.GEMINI:
         if not GEMINI_API_KEY:
             logger.warning("⚠️ Gemini API key not found. Falling back to Ollama.")
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.ZAI:
+        if not ZAI_API_KEY:
+            logger.warning("⚠️ Z.AI API key not found. Falling back to Ollama.")
+        else:
+            logger.info(f"🔄 Using Z.AI provider with model {model_name}")
+            provider = ZAIProvider(api_key=ZAI_API_KEY)
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
+
     return provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    ZAI = "zai"
 
 
 @runtime_checkable
@@ -389,3 +390,27 @@ class GeminiProvider:
                     f"Retrying in {sleep_time}s..."
                 )
                 time.sleep(sleep_time)
+
+# In ModelProvider enum, add:
+ZAI = "zai"
+
+# New provider class:
+class ZAIProvider:
+    """Z.AI provider (OpenAI-compatible)."""
+
+    def __init__(self, api_key: str):
+        from openai import OpenAI
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url="https://api.z.ai/api/paas/v4/"
+        )
+
+    def chat(self, model, messages, options=None, **kwargs):
+        params = {"model": model, "messages": messages}
+        if options:
+            if "temperature" in options:
+                params["temperature"] = options["temperature"]
+            if "top_p" in options:
+                params["top_p"] = options["top_p"]
+        response = self.client.chat.completions.create(**params)
+        return {"message": {"role": "assistant", "content": response.choices[0].message.content}}

--- a/models.py
+++ b/models.py
@@ -20,7 +20,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -282,7 +282,7 @@ class OllamaProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -325,7 +325,7 @@ class GeminiProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Google Gemini API."""
         import re
@@ -376,7 +376,7 @@ class GeminiProvider:
                 api_hint = float(match.group(1)) if match else None
 
                 # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
-                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
 
                 # Prefer the API hint when it is shorter than our computed delay
                 delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay
@@ -391,8 +391,10 @@ class GeminiProvider:
                 )
                 time.sleep(sleep_time)
 
+
 # In ModelProvider enum, add:
 ZAI = "zai"
+
 
 # New provider class:
 class ZAIProvider:
@@ -400,10 +402,8 @@ class ZAIProvider:
 
     def __init__(self, api_key: str):
         from openai import OpenAI
-        self.client = OpenAI(
-            api_key=api_key,
-            base_url="https://api.z.ai/api/paas/v4/"
-        )
+
+        self.client = OpenAI(api_key=api_key, base_url="https://api.z.ai/api/paas/v4/")
 
     def chat(self, model, messages, options=None, **kwargs):
         params = {"model": model, "messages": messages}
@@ -413,4 +413,9 @@ class ZAIProvider:
             if "top_p" in options:
                 params["top_p"] = options["top_p"]
         response = self.client.chat.completions.create(**params)
-        return {"message": {"role": "assistant", "content": response.choices[0].message.content}}
+        return {
+            "message": {
+                "role": "assistant",
+                "content": response.choices[0].message.content,
+            }
+        }

--- a/prompt.py
+++ b/prompt.py
@@ -64,7 +64,7 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
-    # ZAI GLM Models 
+    # ZAI GLM Models
     "glm-4.5-flash": ModelProvider.ZAI,
     "glm-4.7-flash": ModelProvider.ZAI,
 }

--- a/prompt.py
+++ b/prompt.py
@@ -41,6 +41,9 @@ MODEL_PARAMETERS = {
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # ZAI Models
+    "glm-4.5-flash": {"temperature": 0.1, "top_p": 0.9},
+    "glm-4.7-flash": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -61,7 +64,12 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
+    # ZAI GLM Models 
+    "glm-4.5-flash": ModelProvider.ZAI,
+    "glm-4.7-flash": ModelProvider.ZAI,
 }
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+
+ZAI_API_KEY = os.environ.get("ZAI_API_KEY", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pymupdf4llm==0.0.27
 Jinja2==3.1.6
 google-generativeai==0.4.0
 python-dotenv==1.0.1
-black==25.9.0
+black==25.9.0openai==2.44.0


### PR DESCRIPTION
## Problem
Currently the project only supports Ollama (local) and Google Gemini (paid). 
There's no free hosted provider option for users without a GPU or paid API key.

## Solution
Add Z.AI (GLM) as a third provider. Z.AI offers free tier models (GLM-4.5-Flash, GLM-4.7-Flash) 
with no credit card required, and is OpenAI-compatible so integration is clean.

## Changes
- Add `ZAI` to `ModelProvider` enum in `models.py`
- Add `ZAIProvider` class using `openai` SDK with Z.AI base URL
- Add Z.AI models to `MODEL_PARAMETERS` and `MODEL_PROVIDER_MAPPING` in `prompt.py`
- Update `llm_utils.py` to initialize `ZAIProvider` when `LLM_PROVIDER=zai`
- Add `ZAI_API_KEY` env var support

## Tested
Verified working with `glm-4.5-flash` on a real resume end-to-end.

closes #310 