### PR TITLE
fix: strip bare ``` code fences in extract_json_from_response

### DIFF
--- a/llm_utils.py
+++ b/llm_utils.py
@@ -3,11 +3,14 @@ Utility functions for LLM providers.
 """
 
 import logging
+import re
 from typing import Any, Dict, Optional
 from models import ModelProvider, OllamaProvider, GeminiProvider
 from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
 
 logger = logging.getLogger(__name__)
+
+_CODE_FENCE_PATTERN = re.compile(r"^```(?:json)?\s*\n?(.*?)\n?```$", re.DOTALL)
 
 
 def extract_json_from_response(response_text: str) -> str:
@@ -27,14 +30,14 @@ def extract_json_from_response(response_text: str) -> str:
         think_end = response_text.find("</think>")
         if think_start != -1 and think_end != -1:
             response_text = response_text[:think_start] + response_text[think_end + 8 :]
+        response_text = response_text.strip()
 
-    # Remove leading ```json if present
-    if response_text.startswith("```json"):
-        response_text = response_text[7:]
-    # Remove trailing ``` if present
-    if response_text.endswith("```"):
-        response_text = response_text[:-3]
-    return response_text
+    # Strip a wrapping ```json ... ``` or bare ``` ... ``` fence, if present.
+    match = _CODE_FENCE_PATTERN.match(response_text)
+    if match:
+        response_text = match.group(1)
+
+    return response_text.strip()
 
 
 def initialize_llm_provider(model_name: str) -> Any:


### PR DESCRIPTION
Fixes #312

## Problem

`extract_json_from_response()` in `llm_utils.py` only stripped the leading fence when it was exactly ` ```json `. A bare ` ``` ` fence (no language tag) — which some models, especially local Ollama models, sometimes emit — left a dangling ` ``` ` at the start of the string, which broke `json.loads` downstream in `pdf.py`, `github.py`, and `evaluator.py`.

## Fix

Replaced the fixed prefix/suffix string checks with a regex that matches both `​```json` and bare `​```` fences, with optional surrounding whitespace/newlines:

```python
_CODE_FENCE_PATTERN = re.compile(r"^```(?:json)?\s*\n?(.*?)\n?```$", re.DOTALL)
```

## Testing

Verified locally against 6 cases:
- bare fence (the bug) — now parses correctly
- `json`-tagged fence — unchanged behavior
- no fence at all — unchanged behavior
- fence with trailing whitespace/newline
- `<think>...</think>` tag followed by a fence
- fence with no newline after the opening backticks

Also ran a full end-to-end smoke test (`python score.py <resume>.pdf`) against the Gemini provider with a fresh cache — pipeline completed successfully with no regressions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)