### PR TITLE
fix: don't abort extraction when a resume section is legitimately empty

### DIFF
--- a/pdf.py
+++ b/pdf.py
@@ -289,7 +289,7 @@ class PDFHandler:
         for section_name in sections:
             section_data = self._extract_section_data(text_content, section_name)
 
-            if section_data:
+            if section_data is not None:
                 complete_resume.update(section_data)
                 logger.debug(f"✅ Successfully extracted {section_name} section")
             else:


### PR DESCRIPTION
## Problem

`_extract_all_sections_separately` aborts the entire extraction and returns `None` whenever **any** section extracts to an empty result. In practice this means **any resume that is missing an optional section (e.g. no "Awards") gets no score at all.**

Root cause is a truthiness check in `pdf.py`:

```python
section_data = self._extract_section_data(text_content, section_name)

if section_data:                     # <-- empty dict {} is falsy
    complete_resume.update(section_data)
else:
    logger.error("⚠️ Failed to extract ... Aborting extraction ...")
    return None
```

`_call_llm_for_section` returns:
- `None` on a **real failure** (JSON parse error / exception), and
- `{}` for a **valid but empty section** (the resume genuinely has no awards/etc.).

Because `{}` is falsy, a legitimately-empty section is misclassified as a failure and kills the whole run.

## Reproduction

Any resume without an "Awards" section. With Ollama + `qwen2.5:7b`:

```
✅ Successfully extracted basics section
✅ Successfully extracted work section
✅ Successfully extracted education section
✅ Successfully extracted skills section
✅ Successfully extracted projects section
⚠️ Failed to extract awards section. Aborting extraction to prevent partial/invalid resume data.
```

The `awards` LLM call actually **succeeds** — it just returns `{}` (no awards present). Confirmed by logging the return value: `repr(res) == '{}'`, `res is None == False`.

## Fix

Distinguish "real failure" (`None`) from "valid but empty" (`{}`) by checking `is not None`:

```python
if section_data is not None:
    complete_resume.update(section_data)
else:
    logger.error("⚠️ Failed to extract ... Aborting extraction ...")
    return None
```

This preserves the original fail-safe intent (a genuine failure still aborts to avoid partial/invalid data) while allowing resumes with empty optional sections to be scored. An empty section merges as a no-op, leaving that key `None` in the resulting resume — which is the correct representation.

## Before / after

Same resume (no awards), same model:

- **Before:** `⚠️ Failed to extract awards section. Aborting extraction ...` → pipeline returns `None`, no evaluation.
- **After:** all six sections process, `awards` stays empty, and the full evaluation runs to completion and prints a score.

## Validation

Ran the full `score.py` pipeline on a real resume (no awards section) with Ollama `qwen2.5:7b`, before and after the change. Before: aborts at `awards`. After: completes end-to-end and produces the evaluation output + CSV row. One-line change; no formatting drift (`black` clean).
