### PR TITLE
fix: clamp out-of-range evaluation scores instead of crashing

### DIFF
--- a/models.py
+++ b/models.py
@@ -215,10 +215,33 @@ class JSONResume(BaseModel):
     projects: Optional[List[Project]] = None
 
 
+def _clamp_number(value, low=None, high=None):
+    """Clamp a numeric value into [low, high].
+
+    Non-numeric inputs are returned unchanged so pydantic still raises its
+    normal type error. Used to keep out-of-range LLM outputs (e.g. a negative
+    deduction total) from failing validation and crashing the evaluation.
+    """
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return value
+    if low is not None and num < low:
+        num = low
+    if high is not None and num > high:
+        num = high
+    return num
+
+
 class CategoryScore(BaseModel):
     score: float = Field(ge=0, description="Score achieved in this category")
     max: int = Field(gt=0, description="Maximum possible score")
     evidence: str = Field(min_length=1, description="Evidence supporting the score")
+
+    @field_validator("score", mode="before")
+    @classmethod
+    def _clamp_score(cls, v):
+        return _clamp_number(v, low=0)
 
 
 class Scores(BaseModel):
@@ -232,6 +255,11 @@ class BonusPoints(BaseModel):
     total: float = Field(ge=0, le=20, description="Total bonus points")
     breakdown: str = Field(description="Breakdown of bonus points")
 
+    @field_validator("total", mode="before")
+    @classmethod
+    def _clamp_total(cls, v):
+        return _clamp_number(v, low=0, high=20)
+
 
 class Deductions(BaseModel):
     total: float = Field(
@@ -239,6 +267,11 @@ class Deductions(BaseModel):
         description="Total deduction points (stored as positive, applied as negative)",
     )
     reasons: str = Field(description="Reasons for deductions")
+
+    @field_validator("total", mode="before")
+    @classmethod
+    def _clamp_total(cls, v):
+        return _clamp_number(v, low=0)
 
 
 class EvaluationData(BaseModel):


### PR DESCRIPTION
## Problem

`ResumeEvaluator.evaluate_resume` constructs the result directly from the LLM's JSON:

```python
evaluation_dict = json.loads(response_text)
evaluation_data = EvaluationData(**evaluation_dict)   # <-- validates here
```

Several numeric fields carry range constraints:

```python
class CategoryScore(BaseModel):
    score: float = Field(ge=0, ...)
class BonusPoints(BaseModel):
    total: float = Field(ge=0, le=20, ...)
class Deductions(BaseModel):
    total: float = Field(ge=0, ...)
```

LLMs do not reliably honor these bounds. When the model returns an out-of-range value — e.g. a **negative `deductions.total`** — pydantic raises a `ValidationError` that propagates out of `evaluate_resume` and **aborts the entire run with no score at all.**

## Reproduction

Observed on a real resume (Ollama + `qwen2.5:7b`): the model returned a negative deduction total, and the run died with:

```
deductions.total
  Input should be greater than or equal to 0 [type=greater_than_equal, input_value=-5, input_type=int]
```

The same crash is reachable for `bonus_points.total` (e.g. the model returns `> 20`) and any `CategoryScore.score` (negative), since they share the identical pattern.

## Fix

Add `mode="before"` field validators that clamp the numeric evaluation fields into their declared range **before** validation runs:

| Field | Clamp |
|-------|-------|
| `Deductions.total` | `>= 0` (a negative deduction is nonsensical) |
| `BonusPoints.total` | `[0, 20]` |
| `CategoryScore.score` | `>= 0` |

In-range values are untouched, so normal evaluations are unaffected. Non-numeric input still falls through to pydantic's normal type error (the clamp helper returns it unchanged). This makes evaluation resilient to imperfect model output instead of crashing on it.

## Validation

Model-level checks (no LLM required), covering the exact crash and the sibling fields:

```
Deductions(total=-5)        -> total == 0.0    (was: ValidationError / crash)
BonusPoints(total=25)       -> total == 20.0
BonusPoints(total=-3)       -> total == 0.0
CategoryScore(score=-3)     -> score == 0.0
Deductions(total=3)         -> total == 3.0    (in-range untouched)
CategoryScore(score=15)     -> score == 15.0   (in-range untouched)
```

Plus a full `EvaluationData(...)` build with a negative `deductions.total` (the exact failing case) now constructs successfully instead of raising. All checks pass.

Single-file change to `models.py`; the added code is Black-formatted (no unrelated reformatting included).
