### PR TITLE
Integrate OpenAI compatible custom provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,19 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
-LLM_PROVIDER=ollama
+# Options: "ollama", "gemini", or "custom"
+LLM_PROVIDER=gemini
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
-DEFAULT_MODEL=gemma3:4b
+# For Custom: "custom-gpt-4o-mini", "custom-claude-sonnet-4", etc.
+DEFAULT_MODEL=gemini-2.5-pro
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# Custom OpenAI-compatible Provider (required if using "custom" provider)
+# Base URL for the API (e.g. OpenRouter, Together AI, vLLM, etc.)
+# CUSTOM_API_BASE_URL=https://openrouter.ai/api/v1
+# CUSTOM_API_KEY=sk-or-v1-...
+# Models with this prefix are auto-routed to the custom provider
+# CUSTOM_MODEL_PREFIX=custom-

--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,6 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+Shaswat_Singh_resume.pdf
+uv.lock
+pyproject.toml

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Overview
 
-Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use Google Gemini.
+Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama, use Google Gemini, or any OpenAI-compatible provider (OpenRouter, Together AI, vLLM, etc.).
 
 ---
 
@@ -90,6 +90,7 @@ Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a lo
   - **Ollama** for local models
     Install from the [official site](https://ollama.com/), then run `ollama serve`.
   - **Google Gemini** if you have an API key, get it from [here](https://aistudio.google.com/api-keys).
+- **Custom OpenAI-compatible provider** (OpenRouter, Together AI, vLLM, etc.) — see the [Custom Provider](#custom-provider) section.
 
 ### Quick setup with pip
 
@@ -138,9 +139,12 @@ $ cp .env.example .env
 
 | Variable         | Values                                      | Description                                                            |
 | ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
+| `LLM_PROVIDER`   | `ollama`, `gemini`, or `custom`             | Chooses provider. Defaults to Ollama.                                  |
 | `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
 | `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
+| `CUSTOM_API_KEY` | string                                      | Required when `LLM_PROVIDER=custom`.                                   |
+| `CUSTOM_API_BASE_URL` | string                                 | Base URL for OpenAI-compatible API (e.g. `https://openrouter.ai/api/v1`). |
+| `CUSTOM_MODEL_PREFIX` | string (default `custom-`)             | Models starting with this prefix auto-route to custom provider.        |
 | `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
@@ -265,6 +269,25 @@ What happens:
 - Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
+
+### Custom Provider (OpenAI-compatible)
+
+Use any OpenAI-compatible API — OpenRouter, Together AI, vLLM, LM Studio, etc.
+
+**Setup:**
+
+1. Set `LLM_PROVIDER=custom`
+2. Set `CUSTOM_API_BASE_URL` to the provider's base URL (e.g. `https://openrouter.ai/api/v1`)
+3. Set `CUSTOM_API_KEY` to your API key
+4. Set `DEFAULT_MODEL` to `custom-<model-name>` (the `custom-` prefix auto-routes to this provider)
+
+Alternatively, set `CUSTOM_MODEL_PREFIX` to a different prefix if needed.
+
+**How it works:**
+
+- The `CustomProvider` class uses the `openai` Python SDK under the hood
+- Set `DEFAULT_MODEL=custom-gpt-4o-mini` and the `custom-` prefix routes it to the custom provider
+- Supports structured JSON output via `response_format` for evaluation scoring
 
 ---
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,14 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import ModelProvider, OllamaProvider, GeminiProvider, CustomProvider
+from prompt import (
+    resolve_model_provider,
+    GEMINI_API_KEY,
+    CUSTOM_API_KEY,
+    CUSTOM_API_BASE_URL,
+    CUSTOM_MODEL_PREFIX,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,18 +51,34 @@ def initialize_llm_provider(model_name: str) -> Any:
         model_name: The name of the model to use
 
     Returns:
-        An initialized LLM provider (either OllamaProvider or GeminiProvider)
+        An initialized LLM provider (OllamaProvider, GeminiProvider, or CustomProvider)
     """
-    # Default to Ollama provider
     provider = OllamaProvider()
-    # If using Gemini and API key is available, use Gemini provider
-    model_provider = MODEL_PROVIDER_MAPPING.get(model_name, ModelProvider.OLLAMA)
+    model_provider = resolve_model_provider(model_name)
+
     if model_provider == ModelProvider.GEMINI:
         if not GEMINI_API_KEY:
-            logger.warning("⚠️ Gemini API key not found. Falling back to Ollama.")
+            logger.warning(" Gemini API key not found. Falling back to Ollama.")
         else:
-            logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
+            logger.info(f" Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+
+    elif model_provider == ModelProvider.CUSTOM:
+        if not CUSTOM_API_KEY or not CUSTOM_API_BASE_URL:
+            logger.warning(
+                "Custom provider API key or base URL not set. Falling back to Ollama."
+            )
+        else:
+            logger.info(
+                f"Using Custom API provider ({CUSTOM_API_BASE_URL}) with model {model_name}"
+            )
+            provider = CustomProvider(
+                api_key=CUSTOM_API_KEY,
+                base_url=CUSTOM_API_BASE_URL,
+                model_prefix=CUSTOM_MODEL_PREFIX,
+            )
+
     else:
-        logger.info(f"🔄 Using Ollama provider with model {model_name}")
+        logger.info(f" Using Ollama provider with model {model_name}")
+
     return provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    CUSTOM = "custom"
 
 
 @runtime_checkable
@@ -19,7 +20,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -281,7 +282,7 @@ class OllamaProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -324,7 +325,7 @@ class GeminiProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Google Gemini API."""
         import re
@@ -375,7 +376,7 @@ class GeminiProvider:
                 api_hint = float(match.group(1)) if match else None
 
                 # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
-                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
 
                 # Prefer the API hint when it is shorter than our computed delay
                 delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay
@@ -389,3 +390,59 @@ class GeminiProvider:
                     f"Retrying in {sleep_time}s..."
                 )
                 time.sleep(sleep_time)
+
+
+class CustomProvider:
+    """Generic OpenAI-compatible API provider (OpenRouter, Together, vLLM, etc.)."""
+
+    def __init__(self, api_key: str, base_url: str, model_prefix: str = "custom-"):
+        from openai import OpenAI
+
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.model_prefix = model_prefix
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        opts = options.copy() if options else {}
+        opts.pop("stream", None)
+
+        if model.startswith(self.model_prefix):
+            model = model[len(self.model_prefix) :]
+
+        chat_params = {
+            "model": model,
+            "messages": messages,
+            "temperature": opts.pop("temperature", 0.5),
+            "top_p": opts.pop("top_p", 0.9),
+        }
+
+        if "format" in kwargs:
+            schema = kwargs["format"]
+            chat_params["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "response",
+                    "strict": False,
+                    "schema": schema,
+                },
+            }
+
+        if "stream" in kwargs:
+            chat_params["stream"] = kwargs["stream"]
+
+        try:
+            response = self.client.chat.completions.create(**chat_params)
+        except Exception as e:
+            raise RuntimeError(f"Custom provider API call failed: {e}") from e
+
+        return {
+            "message": {
+                "role": "assistant",
+                "content": response.choices[0].message.content,
+            }
+        }

--- a/prompt.py
+++ b/prompt.py
@@ -43,6 +43,11 @@ MODEL_PARAMETERS = {
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
 }
 
+# Custom provider configuration
+CUSTOM_API_KEY = os.getenv("CUSTOM_API_KEY", "")
+CUSTOM_API_BASE_URL = os.getenv("CUSTOM_API_BASE_URL", "")
+CUSTOM_MODEL_PREFIX = os.getenv("CUSTOM_MODEL_PREFIX", "custom-")
+
 # Model provider mapping
 # Maps model names to their provider
 MODEL_PROVIDER_MAPPING = {
@@ -65,3 +70,12 @@ MODEL_PROVIDER_MAPPING = {
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+
+
+def resolve_model_provider(model_name: str) -> ModelProvider:
+    """Resolve provider for a model, checking env-based overrides first."""
+    if PROVIDER == ModelProvider.CUSTOM.value:
+        return ModelProvider.CUSTOM
+    if model_name and model_name.startswith(CUSTOM_MODEL_PREFIX):
+        return ModelProvider.CUSTOM
+    return MODEL_PROVIDER_MAPPING.get(model_name, DEFAULT_PROVIDER)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,6 @@ pymupdf4llm==0.0.27
 Jinja2==3.1.6
 google-generativeai==0.4.0
 python-dotenv==1.0.1
+openai==1.68.2
 black==25.9.0
+openai


### PR DESCRIPTION
## Summary

Adds full support for any OpenAI-compatible API provider (OpenRouter, Together AI, vLLM, LM Studio, etc.) alongside existing Ollama and Gemini backends.

## Changes

- **models.py:395-448**
  - `CustomProvider`: added `model_prefix` param
  - Strips prefix before API call
  - `strict: False` for broader compatibility
  - `stream` kwarg passthrough
  - Wrapped in `try/except`

- **prompt.py:75-81**
  - `resolve_model_provider`: uses module-level `PROVIDER`/`CUSTOM_MODEL_PREFIX` instead of re-reading env vars
  - Guards against empty `model_name`

- **llm_utils.py:75-79**
  - Passes `CUSTOM_MODEL_PREFIX` to `CustomProvider()` constructor

- **config.py**
  - Removed unused custom provider defaults (already defined in `prompt.py`)

- **.env**
  - Added custom provider config vars:
    - `CUSTOM_API_BASE_URL`
    - `CUSTOM_API_KEY`
    - `CUSTOM_MODEL_PREFIX`

- **README.md**
  - Added **Custom Provider (OpenAI-compatible)** section under Provider details
  - Updated config table and overview

## Usage

```env
LLM_PROVIDER=custom
CUSTOM_API_BASE_URL=https://openrouter.ai/api/v1
CUSTOM_API_KEY=sk-or-v1-...
DEFAULT_MODEL=gpt-4o-mini
```

Auto-routing via prefix also works:

```env
DEFAULT_MODEL=custom-gpt-4o-mini # custom- prefix triggers CustomProvider
```

The prefix (`custom-`) is stripped before the API call, so the provider receives `gpt-4o-mini`.

## Validation

- Black formatting applied to all modified files
- Syntax verified (`ast.parse` passes on all changed files)
- End-to-end run completes: provider initializes, PDF extracts, GitHub enriches, evaluation scores
- Both explicit (`LLM_PROVIDER=custom`) and prefix-based routing work