### PR TITLE
feat: add OpenRouter provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,21 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "openrouter"
 LLM_PROVIDER=ollama
 
 # Default model to use
-# For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
-# For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For Ollama:     "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
+# For Gemini:     "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For OpenRouter: use the full OpenRouter model id, e.g.
+#                 "openai/gpt-4o-mini", "google/gemini-2.5-flash-lite",
+#                 "deepseek/deepseek-chat", "meta-llama/llama-3.3-70b-instruct"
 DEFAULT_MODEL=gemma3:4b
 
-# Google Gemini API Key (required if using Gemini provider)
+# Google Gemini API Key (required if LLM_PROVIDER=gemini)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# OpenRouter API Key (required if LLM_PROVIDER=openrouter)
+# Get one at https://openrouter.ai/keys
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+
+# Optional: override the OpenRouter base URL (defaults to the value below)
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Overview
 
-Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use Google Gemini.
+Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama, or use a hosted provider such as Google Gemini or OpenRouter.
 
 ---
 
@@ -136,12 +136,14 @@ $ cp .env.example .env
 
 **Environment variables**
 
-| Variable         | Values                                      | Description                                                            |
-| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
-| `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
-| `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
+| Variable             | Values                                      | Description                                                            |
+| -------------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
+| `LLM_PROVIDER`       | `ollama`, `gemini`, or `openrouter`         | Chooses provider. Defaults to Ollama.                                  |
+| `DEFAULT_MODEL`      | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
+| `GEMINI_API_KEY`     | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
+| `OPENROUTER_API_KEY` | string                                      | Required when `LLM_PROVIDER=openrouter`.                              |
+| `OPENROUTER_BASE_URL`| optional                                    | Overrides the OpenRouter endpoint. Defaults to the public API.         |
+| `GITHUB_TOKEN`       | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
 
@@ -265,6 +267,15 @@ What happens:
 - Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
+
+### OpenRouter
+
+- Set `LLM_PROVIDER=openrouter`
+- Set `DEFAULT_MODEL` to any full OpenRouter model id, for example `openai/gpt-4o-mini`, `google/gemini-2.5-flash-lite`, or `deepseek/deepseek-chat`
+- Provide `OPENROUTER_API_KEY` (get one at https://openrouter.ai/keys)
+- Optionally override `OPENROUTER_BASE_URL`
+- OpenRouter exposes an OpenAI-compatible endpoint, so `models.OpenRouterProvider` sends the shared message format directly and adapts responses to the unified format
+- Because OpenRouter model ids are open-ended, routing is selected by `LLM_PROVIDER=openrouter` rather than the model-name map used for Ollama and Gemini
 
 ---
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,19 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import (
+    ModelProvider,
+    OllamaProvider,
+    GeminiProvider,
+    OpenRouterProvider,
+)
+from prompt import (
+    MODEL_PROVIDER_MAPPING,
+    GEMINI_API_KEY,
+    OPENROUTER_API_KEY,
+    OPENROUTER_BASE_URL,
+    PROVIDER,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +58,18 @@ def initialize_llm_provider(model_name: str) -> Any:
     Returns:
         An initialized LLM provider (either OllamaProvider or GeminiProvider)
     """
+    # Explicit provider selection via LLM_PROVIDER takes precedence. This is
+    # required for OpenRouter, whose model IDs are open-ended and therefore not
+    # enumerable in MODEL_PROVIDER_MAPPING.
+    if PROVIDER == ModelProvider.OPENROUTER.value:
+        if not OPENROUTER_API_KEY:
+            logger.warning("⚠️ OpenRouter API key not found. Falling back to Ollama.")
+            return OllamaProvider()
+        logger.info(f"🔄 Using OpenRouter provider with model {model_name}")
+        return OpenRouterProvider(
+            api_key=OPENROUTER_API_KEY, base_url=OPENROUTER_BASE_URL
+        )
+
     # Default to Ollama provider
     provider = OllamaProvider()
     # If using Gemini and API key is available, use Gemini provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    OPENROUTER = "openrouter"
 
 
 @runtime_checkable
@@ -19,7 +20,7 @@ class LLMProvider(Protocol):
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to the LLM provider."""
         ...
@@ -281,7 +282,7 @@ class OllamaProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
@@ -324,7 +325,7 @@ class GeminiProvider:
         model: str,
         messages: List[Dict[str, str]],
         options: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, Any]:
         """Send a chat request to Google Gemini API."""
         import re
@@ -375,7 +376,7 @@ class GeminiProvider:
                 api_hint = float(match.group(1)) if match else None
 
                 # Exponential backoff: BASE_DELAY * 2^attempt, capped at MAX_DELAY
-                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
 
                 # Prefer the API hint when it is shorter than our computed delay
                 delay = api_hint if (api_hint and api_hint < exp_delay) else exp_delay
@@ -389,3 +390,100 @@ class GeminiProvider:
                     f"Retrying in {sleep_time}s..."
                 )
                 time.sleep(sleep_time)
+
+
+class OpenRouterProvider:
+    """OpenRouter (OpenAI-compatible) LLM provider implementation.
+
+    OpenRouter exposes an OpenAI-compatible ``/chat/completions`` endpoint that
+    proxies many hosted models (OpenAI, Anthropic, Google, Meta, DeepSeek, ...).
+    Because the wire format matches what the rest of this codebase already uses
+    (``system``/``user`` message roles), no message remapping is required.
+    """
+
+    def __init__(self, api_key: str, base_url: str = "https://openrouter.ai/api/v1"):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Send a chat request to OpenRouter and adapt the response.
+
+        Returns an Ollama-shaped dict — ``{"message": {"content": ...}}`` — so
+        callers stay provider-agnostic.
+        """
+        import time
+        import random
+        import requests
+
+        options = options or {}
+
+        payload: Dict[str, Any] = {"model": model, "messages": messages}
+        if "temperature" in options:
+            payload["temperature"] = options["temperature"]
+        if "top_p" in options:
+            payload["top_p"] = options["top_p"]
+
+        # The rest of the codebase requests structured output via an Ollama-style
+        # ``format`` kwarg (a JSON schema). OpenRouter's equivalent is
+        # ``response_format``; JSON-object mode is the most broadly supported
+        # option across the many models OpenRouter proxies.
+        want_json = bool(kwargs.get("format"))
+        if want_json:
+            payload["response_format"] = {"type": "json_object"}
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            # Optional attribution headers recommended by OpenRouter.
+            "X-Title": "hiring-agent",
+        }
+
+        url = f"{self.base_url}/chat/completions"
+
+        MAX_RETRIES = 5
+        BASE_DELAY = 5.0  # seconds — base for exponential backoff
+        MAX_DELAY = 60.0  # cap so we never wait more than a minute
+
+        for attempt in range(MAX_RETRIES):
+            response = requests.post(url, headers=headers, json=payload, timeout=120)
+
+            # Some models proxied by OpenRouter reject ``response_format``.
+            # Fall back once by retrying the request without it.
+            if response.status_code == 400 and "response_format" in payload:
+                payload.pop("response_format", None)
+                continue
+
+            # Retry on rate limits (429) with exponential backoff + jitter.
+            if response.status_code == 429 and attempt < MAX_RETRIES - 1:
+                delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
+                sleep_time = round(delay * random.uniform(0.8, 1.2), 2)
+                print(
+                    f"[OpenRouterProvider] Rate limit hit "
+                    f"(attempt {attempt + 1}/{MAX_RETRIES}). "
+                    f"Retrying in {sleep_time}s..."
+                )
+                time.sleep(sleep_time)
+                continue
+
+            response.raise_for_status()
+            data = response.json()
+
+            try:
+                content = data["choices"][0]["message"]["content"]
+            except (KeyError, IndexError, TypeError) as exc:
+                raise RuntimeError(
+                    f"Unexpected OpenRouter response shape: {data}"
+                ) from exc
+
+            return {"message": {"role": "assistant", "content": content}}
+
+        # Retries exhausted (all attempts were 429s).
+        raise RuntimeError(
+            f"OpenRouter request failed after {MAX_RETRIES} attempts (rate limited)."
+        )

--- a/prompt.py
+++ b/prompt.py
@@ -65,3 +65,10 @@ MODEL_PROVIDER_MAPPING = {
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+
+# OpenRouter configuration (OpenAI-compatible gateway).
+# Routing to OpenRouter is driven by LLM_PROVIDER=openrouter rather than the
+# static model map above, because OpenRouter model IDs are open-ended
+# (e.g. "openai/gpt-4o-mini", "deepseek/deepseek-chat").
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
+OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")


### PR DESCRIPTION
## What

Adds **OpenRouter** (an OpenAI-compatible gateway) as a third `LLM_PROVIDER`, alongside `ollama` and `gemini`. This lets users who have an OpenRouter key — but no local model or Gemini key — run the full pipeline.

## Why

The README positions the project as "run fully local with Ollama, or use a hosted provider." [OpenRouter](https://openrouter.ai) is a popular single-key gateway to many hosted models (OpenAI, Anthropic, Google, Meta, DeepSeek, …), so supporting it removes the hard dependency on either a local GPU or one specific vendor key.

## How

- **`models.py`** — new `OpenRouterProvider` + `ModelProvider.OPENROUTER`. Posts to `/chat/completions`. Because the endpoint is OpenAI-compatible, the existing `system`/`user` message format is sent as-is (no remapping, unlike the Gemini provider). The Ollama-style `format` kwarg (a JSON schema) is mapped to `response_format: {"type": "json_object"}`, with a one-shot fallback that drops it if a proxied model rejects it. 429s are retried with exponential backoff + jitter. Responses are adapted back to the shared `{"message": {"content": ...}}` shape every caller expects.
- **`prompt.py`** — `OPENROUTER_API_KEY` / `OPENROUTER_BASE_URL` env config.
- **`llm_utils.py`** — `initialize_llm_provider` routes to OpenRouter when `LLM_PROVIDER=openrouter`. Routing is keyed on the provider flag (not the static model-name map) because OpenRouter model ids are open-ended (e.g. `openai/gpt-4o-mini`, `deepseek/deepseek-chat`).
- **Docs** — `.env.example` and README "Provider details" updated. **The default provider is unchanged (still `ollama`)** — OpenRouter is purely additive/opt-in.

## Provider-agnostic

No prompt changes and no model-specific tokens. The new class only translates transport (request/response shapes), consistent with `OllamaProvider` and `GeminiProvider`.

## Testing

- Ran the full pipeline end-to-end (`python score.py <resume>.pdf`) on two OpenRouter models — `moonshotai/kimi-k2.6` and `google/gemini-2.5-flash-lite` — each producing a valid evaluation JSON through all four stages (PDF→Markdown, section extraction, GitHub enrichment, evaluation).
- Verified graceful fallback to Ollama when `LLM_PROVIDER=openrouter` but `OPENROUTER_API_KEY` is unset.
- Confirmed existing Ollama/Gemini routing is unchanged.
- `black` clean; no new dependencies (`requests` was already required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
