### PR TITLE
feat: add litellm provider for custom/local LLM endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,31 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "litellm"
 LLM_PROVIDER=ollama
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For litellm (LLM_PROVIDER=litellm), use litellm's "<provider>/<model>" naming, e.g.:
+#   openai/gpt-4o                          (real OpenAI, uses OPENAI_API_KEY)
+#   anthropic/claude-3-5-sonnet-20241022   (real Anthropic, uses ANTHROPIC_API_KEY)
+#   deepseek/deepseek-chat                 (real DeepSeek, uses DEEPSEEK_API_KEY)
+#   gemini/gemini-2.0-flash                (Gemini via litellm, uses GEMINI_API_KEY)
+#   openai/<local-model-name>              (any local OpenAI-compatible server — set LITELLM_API_BASE below)
 DEFAULT_MODEL=gemma3:4b
 
-# Google Gemini API Key (required if using Gemini provider)
+# Google Gemini API Key (required if using Gemini provider, or DEFAULT_MODEL=gemini/... with litellm)
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# litellm settings (only used when LLM_PROVIDER=litellm)
+# LITELLM_API_BASE: base URL override for local/custom OpenAI-compatible servers.
+# Leave empty for real hosted providers (OpenAI/Anthropic/DeepSeek/Gemini) — litellm
+# routes those automatically based on the "<provider>/" prefix in DEFAULT_MODEL.
+# Examples:
+#   LM Studio:            http://localhost:1234/v1
+#   Ollama (OpenAI route): http://localhost:11434/v1
+#   Remote vLLM server:    http://<host>:8000/v1
+LITELLM_API_BASE=
+# LITELLM_API_KEY: generic key for local servers that require a value but don't
+# validate it. Real hosted providers use their own standard env vars instead
+# (OPENAI_API_KEY, ANTHROPIC_API_KEY, DEEPSEEK_API_KEY).
+LITELLM_API_KEY=not-needed

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 **/*.pyc
 resume/*.pdf
+resumes/*.pdf
 run/*.pdf
 test_*.py
 cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ Thanks for your interest in improving this project. Contributions are welcome, i
 
   * One run with Ollama using the default local model.
   * One run with Gemini if you have an API key.
+  * One run with `LLM_PROVIDER=litellm` if you have a local server (LM Studio, vLLM, etc.) or a key for another provider.
 * Add or adjust small smoke tests that exercise each stage with minimal inputs:
 
   * PDF to Markdown

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Overview
 
-Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama or use Google Gemini.
+Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a local or hosted LLM, augments the data with GitHub profile and repository signals, then produces an objective evaluation with category scores, evidence, bonus points, and deductions. You can run fully local with Ollama, use Google Gemini, or route through [litellm](https://docs.litellm.ai/) to any other provider or local OpenAI-compatible server (OpenAI, Anthropic, DeepSeek, LM Studio, vLLM, etc.).
 
 ---
 
@@ -85,11 +85,12 @@ Hiring Agent parses a resume PDF to Markdown, extracts sectioned JSON using a lo
 
   The repository pins `.python-version` to 3.11.13.
 
-- **One LLM backend** (either of them)
+- **One LLM backend** (any of them)
 
   - **Ollama** for local models
     Install from the [official site](https://ollama.com/), then run `ollama serve`.
   - **Google Gemini** if you have an API key, get it from [here](https://aistudio.google.com/api-keys).
+  - **litellm** to use any other provider (OpenAI, Anthropic, DeepSeek, ...) or a local OpenAI-compatible server (LM Studio, vLLM, etc.) — see [Provider details](#provider-details).
 
 ### Quick setup with pip
 
@@ -136,12 +137,14 @@ $ cp .env.example .env
 
 **Environment variables**
 
-| Variable         | Values                                      | Description                                                            |
-| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
-| `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
-| `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
+| Variable           | Values                                                    | Description                                                                       |
+| ------------------ | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `LLM_PROVIDER`     | `ollama`, `gemini`, or `litellm`                          | Chooses provider. Defaults to Ollama.                                             |
+| `DEFAULT_MODEL`    | for example `gemma3:4b`, `gemini-2.5-pro`, `openai/gpt-4o` | Model name passed to the provider. See [Provider details](#provider-details) for the litellm naming convention. |
+| `GEMINI_API_KEY`   | string                                                    | Required when `LLM_PROVIDER=gemini` (or `DEFAULT_MODEL=gemini/...` with litellm). |
+| `LITELLM_API_BASE` | URL, optional                                             | Base URL override for local/custom OpenAI-compatible servers. Only used when `LLM_PROVIDER=litellm`. |
+| `LITELLM_API_KEY`  | string, optional                                          | Generic key for local servers that require a value but don't validate it. Only used when `LLM_PROVIDER=litellm`. |
+| `GITHUB_TOKEN`     | optional                                                  | Inherits from your shell environment, improves GitHub API rate limits.           |
 
 Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
 
@@ -265,6 +268,20 @@ What happens:
 - Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
+
+### litellm (any provider or local endpoint)
+
+Use this to route to a provider not otherwise wired up (OpenAI, Anthropic, DeepSeek, ...) or to a local OpenAI-compatible server such as LM Studio, vLLM, or Ollama's `/v1` route.
+
+- Set `LLM_PROVIDER=litellm`
+- Set `DEFAULT_MODEL` using litellm's `<provider>/<model>` naming convention:
+  - `openai/gpt-4o` — real OpenAI, reads `OPENAI_API_KEY`
+  - `anthropic/claude-3-5-sonnet-20241022` — real Anthropic, reads `ANTHROPIC_API_KEY`
+  - `deepseek/deepseek-chat` — real DeepSeek, reads `DEEPSEEK_API_KEY`
+  - `gemini/gemini-2.0-flash` — Gemini via litellm, reads `GEMINI_API_KEY`
+  - `openai/<local-model-name>` — any local OpenAI-compatible server; also set `LITELLM_API_BASE` (for example `http://localhost:1234/v1` for LM Studio)
+- The wrapper in `models.LiteLLMProvider` calls `litellm.completion` and adapts responses to the same unified format as the other providers
+- This is fully additive: leaving `LLM_PROVIDER` unset or set to `ollama`/`gemini` behaves exactly as before
 
 ---
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,14 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+from models import ModelProvider, OllamaProvider, GeminiProvider, LiteLLMProvider
+from prompt import (
+    MODEL_PROVIDER_MAPPING,
+    GEMINI_API_KEY,
+    PROVIDER,
+    LITELLM_API_BASE,
+    LITELLM_API_KEY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +51,14 @@ def initialize_llm_provider(model_name: str) -> Any:
         model_name: The name of the model to use
 
     Returns:
-        An initialized LLM provider (either OllamaProvider or GeminiProvider)
+        An initialized LLM provider (OllamaProvider, GeminiProvider, or LiteLLMProvider)
     """
+    # litellm handles routing itself, so any model name works without a
+    # MODEL_PROVIDER_MAPPING entry
+    if PROVIDER == ModelProvider.LITELLM.value:
+        logger.info(f"🔄 Using litellm provider with model {model_name}")
+        return LiteLLMProvider(api_base=LITELLM_API_BASE, api_key=LITELLM_API_KEY)
+
     # Default to Ollama provider
     provider = OllamaProvider()
     # If using Gemini and API key is available, use Gemini provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    LITELLM = "litellm"
 
 
 @runtime_checkable
@@ -385,6 +386,83 @@ class GeminiProvider:
 
                 print(
                     f"[GeminiProvider] Rate limit hit "
+                    f"(attempt {attempt + 1}/{MAX_RETRIES}). "
+                    f"Retrying in {sleep_time}s..."
+                )
+                time.sleep(sleep_time)
+
+
+class LiteLLMProvider:
+    """litellm-backed provider implementation. Model names use litellm's
+    "<provider>/<model>" convention, e.g. "openai/gpt-4o" or "deepseek/deepseek-v4-pro"."""
+
+    def __init__(self, api_base: str = "", api_key: str = "not-needed"):
+        import litellm
+
+        self.client = litellm
+        self.api_base = api_base or None
+        self.api_key = api_key or "not-needed"
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Send a chat request via litellm."""
+        import time
+        import random
+        from litellm.exceptions import RateLimitError
+
+        MAX_RETRIES = 5
+        BASE_DELAY = 10.0  # seconds — base for exponential backoff
+        MAX_DELAY = 120.0  # cap so we never wait more than 2 minutes
+
+        options = options or {}
+        completion_kwargs = {
+            "model": model,
+            "messages": messages,
+            "api_base": self.api_base,
+            "api_key": self.api_key,
+        }
+        if "temperature" in options:
+            completion_kwargs["temperature"] = options["temperature"]
+        if "top_p" in options:
+            completion_kwargs["top_p"] = options["top_p"]
+
+        response_format = None
+        if "format" in kwargs:
+            response_format = {
+                "type": "json_schema",
+                "json_schema": {"name": "response", "schema": kwargs["format"]},
+            }
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                if response_format is not None:
+                    try:
+                        response = self.client.completion(
+                            **completion_kwargs, response_format=response_format
+                        )
+                    except Exception:
+                        # not all models support structured outputs
+                        response = self.client.completion(**completion_kwargs)
+                else:
+                    response = self.client.completion(**completion_kwargs)
+
+                content = response.choices[0].message.content
+                return {"message": {"role": "assistant", "content": content}}
+
+            except RateLimitError as e:
+                if attempt == MAX_RETRIES - 1:
+                    raise
+
+                exp_delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
+                sleep_time = round(exp_delay * random.uniform(0.8, 1.2), 2)
+
+                print(
+                    f"[LiteLLMProvider] Rate limit hit "
                     f"(attempt {attempt + 1}/{MAX_RETRIES}). "
                     f"Retrying in {sleep_time}s..."
                 )

--- a/prompt.py
+++ b/prompt.py
@@ -65,3 +65,7 @@ MODEL_PROVIDER_MAPPING = {
 
 # Get API keys from environment
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+
+# litellm settings, used when LLM_PROVIDER=litellm
+LITELLM_API_BASE = os.getenv("LITELLM_API_BASE", "")
+LITELLM_API_KEY = os.getenv("LITELLM_API_KEY", "not-needed")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Jinja2==3.1.6
 google-generativeai==0.4.0
 python-dotenv==1.0.1
 black==25.9.0
+litellm==1.89.2


### PR DESCRIPTION
## Summary
- Adds a third LLM provider backed by litellm, so DEFAULT_MODEL can point at any provider (OpenAI, Anthropic, DeepSeek) or any local OpenAI-compatible server (LM Studio, vLLM, Ollama's /v1 route) without a new provider class per backend.
- Opt-in via LLM_PROVIDER=litellm; existing ollama/gemini behavior is unchanged.

## Test plan
- [x] pip install -r requirements.txt; no dependency conflicts
- [x] Regression: LLM_PROVIDER=ollama (default) still runs unchanged
- [x] New path: LLM_PROVIDER=litellm, DEFAULT_MODEL=deepseek/deepseek-v4-pro; ran end-to-end against a real resume, produced a valid evaluation

Related to #321, #310, #295 ; litellm has built-in support for llama.cpp, NVIDIA NIM,
and Z.AI/GLM (via zhipu/), so this generic provider covers those requests too, in
addition to OpenAI/Anthropic/DeepSeek/any local OpenAI-compatible server.