### PR TITLE
fix: exempt popular open source contributions from 4-commit threshold in project selection prompt

### DIFF
--- a/prompts/templates/github_project_selection.jinja
+++ b/prompts/templates/github_project_selection.jinja
@@ -1,6 +1,6 @@
 You are an expert technical recruiter analyzing GitHub repositories to identify the most impressive and relevant projects for a software engineering position.
 
-**ABSOLUTE REQUIREMENT**: You must ONLY select projects where the author_commit_count is 4 or higher. Projects with 1, 2, or 3 commits indicate minimal involvement and should NEVER be selected.
+**ABSOLUTE REQUIREMENT**: You must ONLY select projects where the author_commit_count is 4 or higher. Projects with 1, 2, or 3 commits indicate minimal involvement and should NEVER be selected — **EXCEPTION**: contributions to popular open source projects (1000+ stars) are exempt from this threshold, even a single commit to a widely-used project demonstrates meaningful community involvement.
 
 Given a list of GitHub repositories, select the TOP 7 most impressive projects that would be most relevant for evaluating a candidate's technical skills and experience.
 
@@ -43,9 +43,9 @@ Given a list of GitHub repositories, select the TOP 7 most impressive projects t
 
 **FILTERING STEP:**
 1. First, sort all projects by author_commit_count in descending order (highest to lowest)
-2. Filter out all projects with author_commit_count less than 4
-3. Only consider projects where the candidate has made at least 4 commits
-4. Start selection from the top of the sorted list (highest commit counts first)
+2. Filter out all projects with author_commit_count less than 4, UNLESS the repository has 1000+ stars (popular open source project)
+3. For popular open source projects (1000+ stars), include them regardless of commit count — even 1 commit is valuable
+4. Start selection from the top of the sorted list (highest commit counts first), then add any qualifying popular open source contributions
 
 **CRITICAL REQUIREMENTS:**
 - Select exactly 7 UNIQUE projects (no duplicates) if 7 or more qualifying projects exist


### PR DESCRIPTION
Fixes #327

## Problem
The `github_project_selection.jinja` prompt had contradictory rules:
- Lines 3 and 44-48 hard-excluded any project with fewer than 4 commits as an "ABSOLUTE REQUIREMENT"
- Lines 12-16 stated that contributions to popular projects (1000+ stars) are "HIGH PRIORITY" even if the contribution is small

This caused the LLM to drop legitimate open source contributions (e.g. a merged bug fix to a 10,000-star repo) in favour of personal projects with higher commit counts.

## Fix
Added an explicit exception to the 4-commit threshold rule for popular open source projects (1000+ stars). Updated the FILTERING STEP to reflect this exception so both rules are consistent and unambiguous.

## Changes
- `prompts/templates/github_project_selection.jinja`: Added exception clause to ABSOLUTE REQUIREMENT and updated FILTERING STEP