### PR TITLE
feat: add llama.cpp provider with environment parameter overrides and lazy loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,23 @@
 # LLM Provider Configuration
-# Options: "ollama" or "gemini"
+# Options: "ollama", "gemini", or "llamacpp"
 LLM_PROVIDER=ollama
 
 # Default model to use
 # For Ollama: "gemma3:4b", "qwen3:4b", "mistral:7b", etc.
 # For Gemini: "gemini-2.5-pro", "gemini-2.5-flash", etc.
+# For LlamaCpp: "/absolute/path/to/model.gguf"
 DEFAULT_MODEL=gemma3:4b
+
+# Llama.cpp Specific Options
+# Llama.cpp Hardware Settings (Safe CPU Defaults)
+# LLAMACPP_MODEL_PATH=/path/to/your/model.gguf
+# Controls how many tokens the model can remember (default: 32768)
+# LLAMACPP_N_CTX=32768
+# Controls how many model layers to offload to the GPU (default: 0)
+# LLAMACPP_N_GPU_LAYERS=0
+# Override temperature for Llama.cpp (default: uses system value, fallback 0.5)
+# LLAMACPP_TEMPERATURE=0.1
+
 
 # Google Gemini API Key (required if using Gemini provider)
 GEMINI_API_KEY=your_gemini_api_key_here

--- a/README.md
+++ b/README.md
@@ -266,7 +266,13 @@ What happens:
 - Provide `GEMINI_API_KEY`
 - The wrapper in `models.GeminiProvider` adapts responses to a unified format
 
----
+### Llama.cpp (Local GGUF Models)
+
+- Set `LLM_PROVIDER=llamacpp`
+- Set `LLAMACPP_MODEL_PATH` to the absolute path of your downloaded `.gguf` file (e.g. `/path/to/model.gguf`)
+- Keep `DEFAULT_MODEL` set to your desired model's logical name (e.g. `qwen3:4b`) so its parameters are correctly mapped.
+- **Hardware Settings:** `LLAMACPP_N_GPU_LAYERS` defaults to 0 (CPU-only) for safety. Set this (e.g., to `-1` for full GPU, or `10` for partial) to enable GPU acceleration. If you encounter Out of Memory crashes on constrained hardware, try lowering `LLAMACPP_N_CTX` from its default of 32768.
+- **Note:** To use raw .gguf files via Llama.cpp instead of Ollama, you must manually install the C++ bindings by running: `pip install llama-cpp-python`. Note that a default install may compile for CPU-only. For hardware acceleration (e.g. CUDA/Metal), follow the compilation instructions in the official `llama-cpp-python` documentation.
 
 ## Contributing
 

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,8 +4,9 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
-from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
+import os
+from models import ModelProvider, OllamaProvider, GeminiProvider, LlamaCppProvider
+from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY, PROVIDER, DEFAULT_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,8 @@ def extract_json_from_response(response_text: str) -> str:
     return response_text
 
 
+_llamacpp_instance = None
+
 def initialize_llm_provider(model_name: str) -> Any:
     """
     Initialize the appropriate LLM provider based on the model name.
@@ -47,6 +50,21 @@ def initialize_llm_provider(model_name: str) -> Any:
     Returns:
         An initialized LLM provider (either OllamaProvider or GeminiProvider)
     """
+    global _llamacpp_instance
+
+    # LlamaCpp provider: uses LLAMACPP_MODEL_PATH env var for model file
+    if PROVIDER == ModelProvider.LLAMACPP.value:
+        model_path = os.environ.get("LLAMACPP_MODEL_PATH")
+        if not model_path or not os.path.exists(model_path):
+            raise FileNotFoundError(
+                f"Llama.cpp model file not found at "
+                f"{model_path or 'LLAMACPP_MODEL_PATH not set'}"
+            )
+        if _llamacpp_instance is None:
+            logger.info(f"Using Llama.cpp provider with model {model_name} from {model_path}")
+            _llamacpp_instance = LlamaCppProvider(model_path=model_path)
+        return _llamacpp_instance
+
     # Default to Ollama provider
     provider = OllamaProvider()
     # If using Gemini and API key is available, use Gemini provider

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    LLAMACPP = "llamacpp"
 
 
 @runtime_checkable
@@ -285,10 +286,16 @@ class OllamaProvider:
     ) -> Dict[str, Any]:
         """Send a chat request to Ollama."""
 
+        import os
         ollama_options = options.copy() if options else {}
 
         # remove steam from ollama options
         ollama_options.pop("stream", None)
+
+        # Allow env var override for temperature
+        env_temp = os.environ.get("OLLAMA_TEMPERATURE") or os.environ.get("LLM_TEMPERATURE")
+        if env_temp is not None:
+            ollama_options["temperature"] = float(env_temp)
 
         # Add num_ctx 32K context window to options
         ollama_options["num_ctx"] = 32768
@@ -389,3 +396,88 @@ class GeminiProvider:
                     f"Retrying in {sleep_time}s..."
                 )
                 time.sleep(sleep_time)
+
+
+class LlamaCppProvider:
+    """
+    Llama.cpp local API provider implementation.
+
+    The llama.cpp backend inherits the project context default of 32k, but defaults to no GPU offload.
+    Users can opt into GPU acceleration by setting LLAMACPP_N_GPU_LAYERS explicitly for their hardware.
+    On constrained systems, large context sizes may still require lowering LLAMACPP_N_CTX,
+    enabling KV-cache quantization, or choosing a smaller model.
+    """
+
+    def __init__(self, model_path: str):
+        try:
+            from llama_cpp import Llama
+        except ImportError:
+            raise ImportError(
+                "Note: llama-cpp-python is an optional dependency for running local GGUF models. "
+                "A default installation may use a CPU-only build, so GPU offloading may not be available "
+                "unless llama-cpp-python is installed with the appropriate platform-specific or GPU-enabled configuration. "
+                "For GPU acceleration, follow the official llama-cpp-python installation instructions: "
+                "https://github.com/abetlen/llama-cpp-python"
+            )
+
+        import os
+
+        # Inherits the project context default of 32k
+        n_ctx = int(os.environ.get("LLAMACPP_N_CTX", "32768"))
+
+        # Defaults to NO GPU offload (0) for safety
+        n_gpu_layers = int(os.environ.get("LLAMACPP_N_GPU_LAYERS", "0"))
+
+        llama_kwargs = {
+            "model_path": model_path,
+            "n_ctx": n_ctx,
+            "n_gpu_layers": n_gpu_layers,
+            "verbose": False
+        }
+
+        self.llama_kwargs = llama_kwargs
+        self.model = None
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Send a chat request to Llama.cpp."""
+
+        import os
+        options = options or {}
+        env_temp = os.environ.get("LLAMACPP_TEMPERATURE")
+        temperature = float(env_temp) if env_temp is not None else options.get("temperature")
+        chat_kwargs = {
+            "messages": messages,
+            "max_tokens": options.get("num_predict", -1),
+            "top_p": options.get("top_p", 0.9),
+        }
+        if temperature is not None:
+            chat_kwargs["temperature"] = temperature
+
+
+
+        if self.model is None:
+            try:
+                from llama_cpp import Llama
+                self.model = Llama(**self.llama_kwargs)
+            except ValueError as e:
+                if "Failed to create llama_context" in str(e):
+                    raise RuntimeError(
+                        f"llama.cpp initialization failed (Likely Out of Memory). "
+                        f"Check your LLAMACPP_N_CTX and LLAMACPP_N_GPU_LAYERS settings."
+                    ) from e
+                else:
+                    raise e
+
+        response = self.model.create_chat_completion(**chat_kwargs)
+
+        return {
+            "model": response.get("model", "llamacpp"),
+            "message": response["choices"][0]["message"]
+        }
+


### PR DESCRIPTION
## Summary
Adds a new `llamacpp` provider for local GGUF models using `llama-cpp-python`.

## Changes
- adds `LlamaCppProvider`
- supports `LLM_PROVIDER=llamacpp`
- reads model path from `LLAMACPP_MODEL_PATH`
- adds environment overrides for llama.cpp settings like context size, GPU layers, and temperature
- lazily initializes the llama.cpp model
- updates `.env.example` and README with setup instructions

## Notes
- defaults to CPU-safe settings (`LLAMACPP_N_GPU_LAYERS=0`)
- requires optional installation of `llama-cpp-python` to use local GGUF files
