### PR TITLE
feat: implement dynamic role-based scoring limits

### DIFF
--- a/DYNAMIC_SCORING.md
+++ b/DYNAMIC_SCORING.md
@@ -1,0 +1,31 @@
+# Dynamic Role-Based Scoring Algorithm
+
+## Overview
+The Hiring Agent evaluates resumes on a standardized **120-point scale** (100 base points + 20 bonus points). Previously, the maximum points a candidate could earn in any given category (e.g., Open Source, Production) were hardcoded. 
+
+This created a major discrepancy: A Senior Engineer lacking open source contributions would lose up to 35 points, even if they had immense production impact. Conversely, an Intern with incredible side projects was capped at 30 points and penalized for lacking professional experience.
+
+To solve this, the agent now employs a **Dynamic Scoring Algorithm**. The 100 base points dynamically shift and re-allocate their maximum limits based on the candidate's target role.
+
+## Category Weight Distribution
+
+The following table dictates the maximum possible score for each category depending on the `--experience` level passed to the CLI. These weights are configured in `roles.py`.
+
+| Role | Open Source | Self Projects | Production | Tech Skills | Total |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Intern** | 30 | 45 | 10 | 15 | 100 |
+| **Entry** | 25 | 35 | 20 | 20 | 100 |
+| **Junior** | 20 | 25 | 35 | 20 | 100 |
+| **Mid** | 15 | 20 | 45 | 20 | 100 |
+| **Senior** | 15 | 15 | 45 | 25 | 100 |
+| **Staff/Principal** | 15 | 15 | 45 | 25 | 100 |
+
+*Note: `open_source` and `self_projects` never drop below 15 maximum points. This ensures that startup founders, entrepreneurs, and active open-source maintainers always receive credit for their external work, even at the Principal engineering level.*
+
+## How It Works Under the Hood
+
+1. **Role Identification**: When `score.py` is executed, the `--experience` argument maps to a specific dictionary in `roles.py` called `ROLE_MAX_SCORES`.
+2. **Context Injection**: The `evaluator.py` module fetches these `max_weights` and passes them directly into the Jinja2 template rendering context.
+3. **Dynamic Prompt Math**: Instead of using static text bounds (e.g., `HIGH SCORES (25-35 points)`), the prompt templates use Jinja math to calculate the qualitative score bounds as a percentage of the dynamic maximum. 
+
+For example, if evaluating a Senior Engineer, the Jinja template dynamically renders the prompt to cap Self Projects at 15 points, and shifts the definition of a "High Score" to be roughly 9-15 points. Because all math is computed prior to sending the prompt to the LLM (Gemini or Ollama), the system remains perfectly declarative and provider-agnostic.

--- a/README.md
+++ b/README.md
@@ -203,10 +203,19 @@ You can leave it on during iteration. See the next section for details.
 
 ### End to end scoring
 
-Provide a path to a resume PDF.
+Provide a path to a resume PDF and optionally specify the target experience level using the `--e` flag. 
 
 ```bash
-$ python score.py /path/to/resume.pdf
+$ python score.py /path/to/resume.pdf --e entry
+```
+*Available experience levels: `intern`, `entry`, `junior` (0-2 years), `mid` (2-5 years), `senior` (5+ years), `staff`, `principal`. Defaults to `intern` if omitted.*
+
+### View all options
+
+To see all available commands and arguments, use the help flag:
+
+```bash
+$ python score.py -h
 ```
 
 What happens:

--- a/evaluator.py
+++ b/evaluator.py
@@ -17,6 +17,7 @@ from prompt import (
     GEMINI_API_KEY,
 )
 from prompts.template_manager import TemplateManager
+from roles import EXPERIENCE_LEVELS, ROLE_PRIORITIES, ROLE_MAX_SCORES
 
 logger = logging.getLogger(__name__)
 
@@ -37,21 +38,45 @@ class ResumeEvaluator:
         """Initialize the appropriate LLM provider based on the model."""
         self.provider = initialize_llm_provider(self.model_name)
 
-    def _load_evaluation_prompt(self, resume_text: str) -> str:
+    def _load_evaluation_prompt(
+        self,
+        resume_text: str,
+        experience_level_name: str,
+        priorities: List[str],
+        max_weights: dict,
+    ) -> str:
         criteria_template = self.template_manager.render_template(
-            "resume_evaluation_criteria", text_content=resume_text
+            "resume_evaluation_criteria",
+            text_content=resume_text,
+            experience_level_name=experience_level_name,
+            priorities=priorities,
+            max_weights=max_weights,
         )
         if criteria_template is None:
             raise ValueError("Failed to load resume evaluation criteria template")
         return criteria_template
 
-    def evaluate_resume(self, resume_text: str) -> EvaluationData:
+    def evaluate_resume(
+        self, resume_text: str, experience_level: str = "intern"
+    ) -> EvaluationData:
         self._last_resume_text = resume_text
-        full_prompt = self._load_evaluation_prompt(resume_text)
+
+        experience_level_name = EXPERIENCE_LEVELS.get(
+            experience_level, "Software Intern"
+        )
+        priorities = ROLE_PRIORITIES.get(experience_level, [])
+        max_weights = ROLE_MAX_SCORES.get(experience_level, ROLE_MAX_SCORES["intern"])
+
+        full_prompt = self._load_evaluation_prompt(
+            resume_text, experience_level_name, priorities, max_weights
+        )
         # logger.info(f"🔤 Evaluation prompt being sent: {full_prompt}")
         try:
             system_message = self.template_manager.render_template(
-                "resume_evaluation_system_message"
+                "resume_evaluation_system_message",
+                experience_level_name=experience_level_name,
+                priorities=priorities,
+                max_weights=max_weights,
             )
             if system_message is None:
                 raise ValueError(

--- a/prompts/templates/resume_evaluation_criteria.jinja
+++ b/prompts/templates/resume_evaluation_criteria.jinja
@@ -1,4 +1,15 @@
-You are evaluating a resume for a Software Intern position at HackerRank. Analyze the resume data and provide scores based on these criteria:
+You are evaluating a resume for a position at HackerRank. Analyze the resume data and provide scores based on these criteria.
+
+## TARGET ROLE
+Target Role: {{ experience_level_name }}
+
+## ROLE EXPECTATIONS & PRIORITIES
+Based on the target role, prioritize the following areas when evaluating and scoring:
+{% for item in priorities %}
+- {{ item }}
+{% endfor %}
+
+Keep the maximum scores for each category fixed as outlined below, but adjust your expectations for what constitutes a "good" score based on the role priorities above. For example, a Senior candidate should demonstrate high production impact and leadership, while an Intern should demonstrate potential through projects and learning.
 
 **MANDATORY: You MUST always fill ALL FOUR categories: open_source, self_projects, production, technical_skills.**
 
@@ -31,25 +42,25 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 
 ## SCORING CRITERIA
 
-### Open Source (0-35 points)
-**HIGH SCORES (25-35 points):**
+### Open Source (0-{{ max_weights.open_source }} points)
+**HIGH SCORES ({{ (max_weights.open_source * 0.7) | int }}-{{ max_weights.open_source }} points):**
 - Contributions to popular open source projects (1000+ stars)
 - Significant contributions to well-known projects
 - Google Summer of Code (GSoC) participation
 - Substantial community involvement
 
-**MEDIUM SCORES (15-24 points):**
+**MEDIUM SCORES ({{ (max_weights.open_source * 0.4) | int }}-{{ (max_weights.open_source * 0.7) | int - 1 }} points):**
 - Contributions to smaller open source projects
 - Active GitHub presence with meaningful contributions to other repositories
 - Participation in open source programs
 
-**LOW SCORES (5-10 points):**
+**LOW SCORES ({{ (max_weights.open_source * 0.15) | int }}-{{ (max_weights.open_source * 0.4) | int - 1 }} points):**
 - Only personal GitHub repositories with no contributions to other projects
 - Minimal open source activity
 - Basic GitHub presence
-- **CRITICAL**: Hacktoberfest participation alone (without evidence of contributions to significant projects) should receive 3-5 points maximum
+- **CRITICAL**: Hacktoberfest participation alone (without evidence of contributions to significant projects) should receive {{ (max_weights.open_source * 0.1) | int }}-{{ (max_weights.open_source * 0.15) | int }} points maximum
 
-**VERY LOW SCORES (0-4 points):**
+**VERY LOW SCORES (0-{{ (max_weights.open_source * 0.15) | int - 1 }} points):**
 - No GitHub presence
 - Only very basic personal repositories
 - Repositories that are clearly tutorial-based with no community involvement
@@ -57,19 +68,19 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 **CRITICAL RULES:**
 - Having personal GitHub repositories does NOT constitute open source contribution
 - True open source contribution means contributing to OTHER people's projects
-- When GitHub data shows all projects are 'self_project' type, open source score MUST be 10 points or less
+- When GitHub data shows all projects are 'self_project' type, open source score MUST be {{ (max_weights.open_source * 0.3) | int }} points or less
 
-### Self Projects (0-30 points)
-**HIGH SCORES (20-30 points):**
+### Self Projects (0-{{ max_weights.self_projects }} points)
+**HIGH SCORES ({{ (max_weights.self_projects * 0.65) | int }}-{{ max_weights.self_projects }} points):**
 - Complex projects with real-world impact
 - Advanced architecture, multiple technologies
 - User adoption or contributions to popular open source projects
 
-**MEDIUM SCORES (10-19 points):**
+**MEDIUM SCORES ({{ (max_weights.self_projects * 0.35) | int }}-{{ (max_weights.self_projects * 0.65) | int - 1 }} points):**
 - Projects with some complexity, good documentation
 - Multiple features or moderate technical challenge
 
-**LOW SCORES (1-9 points):**
+**LOW SCORES (1-{{ (max_weights.self_projects * 0.35) | int - 1 }} points):**
 - Simple tutorial projects (todo lists, calculators, basic CRUD apps, weather apps, note-taking apps, recipe apps, exercise apps)
 - Basic sentiment analysis using standard libraries (NLTK, scikit-learn)
 - Classroom assignments or projects with minimal technical complexity
@@ -82,11 +93,11 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 - **INACTIVE LINKS**: Projects with broken links should receive 20-30% lower scores
 - **LIVE DEMO BONUS**: Projects with working live demos should receive 10-20% higher scores
 
-### Production (0-25 points)
+### Production (0-{{ max_weights.production }} points)
 - Analyze the 'work' and 'volunteer' sections for real-world, internship, or production experience
 - **SPECIAL CONSIDERATION**: Give extra points for founder roles, co-founder positions, or early-stage engineer roles (first 10-20 employees) at startups
 
-### Technical Skills (0-10 points)
+### Technical Skills (0-{{ max_weights.technical_skills }} points)
 - Analyze the 'skills', 'languages', and evidence of technical breadth or problem-solving in projects, work, or competitions
 
 ## PROJECT COMPLEXITY ASSESSMENT
@@ -108,6 +119,7 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 - Real-time applications (chat, streaming, etc.)
 - Mobile applications with native features
 - Projects with microservices architecture
+- Cybersecurity tools, penetration testing frameworks, or advanced cryptography
 - Contributions to popular open source projects
 - Projects with significant user adoption
 - Projects solving real-world problems
@@ -138,8 +150,8 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 
 **CRITICAL ENFORCEMENT:**
 - When GitHub data shows all projects are 'self_project' type, apply 3-5 point deductions for lack of true open source contributions
-- For candidates with only personal GitHub repositories, open source score should NEVER exceed 10 points
-- For candidates with only tutorial-based projects, self_projects score should NEVER exceed 15 points
+- For candidates with only personal GitHub repositories, open source score should NEVER exceed {{ (max_weights.open_source * 0.3) | int }} points
+- For candidates with only tutorial-based projects, self_projects score should NEVER exceed {{ (max_weights.self_projects * 0.5) | int }} points
 
 ## CRITICAL REQUIREMENTS
 1. You MUST respond with ONLY the JSON structure below - no summary, no other fields
@@ -156,10 +168,10 @@ You are evaluating a resume for a Software Intern position at HackerRank. Analyz
 - Evidence fields cannot be empty string
 - All category scores must be >= 0 (cannot be negative)
 - **CATEGORY SCORE LIMITS** (CANNOT be exceeded under any circumstances):
-  - open_source: 0-35 points (maximum 35)
-  - self_projects: 0-30 points (maximum 30)
-  - production: 0-25 points (maximum 25)
-  - technical_skills: 0-10 points (maximum 10)
+  - open_source: 0-{{ max_weights.open_source }} points (maximum {{ max_weights.open_source }})
+  - self_projects: 0-{{ max_weights.self_projects }} points (maximum {{ max_weights.self_projects }})
+  - production: 0-{{ max_weights.production }} points (maximum {{ max_weights.production }})
+  - technical_skills: 0-{{ max_weights.technical_skills }} points (maximum {{ max_weights.technical_skills }})
 - Bonus points total must be <= 20 (maximum 20 points)
 - **OVERALL SCORE LIMIT**: The total score (categories + bonus - deductions) cannot exceed 120 points
 
@@ -169,10 +181,10 @@ Analyze the following resume and provide a JSON response with this EXACT structu
 
 {
     "scores": {
-        "open_source": {"score": 0, "max": 35, "evidence": "string"},
-        "self_projects": {"score": 0, "max": 30, "evidence": "string"},
-        "production": {"score": 0, "max": 25, "evidence": "string"},
-        "technical_skills": {"score": 0, "max": 10, "evidence": "string"}
+        "open_source": {"score": 0, "max": {{ max_weights.open_source }}, "evidence": "string"},
+        "self_projects": {"score": 0, "max": {{ max_weights.self_projects }}, "evidence": "string"},
+        "production": {"score": 0, "max": {{ max_weights.production }}, "evidence": "string"},
+        "technical_skills": {"score": 0, "max": {{ max_weights.technical_skills }}, "evidence": "string"}
     },
     "bonus_points": {"total": 0, "breakdown": "string"},
     "deductions": {"total": 0, "reasons": "string"},

--- a/prompts/templates/resume_evaluation_system_message.jinja
+++ b/prompts/templates/resume_evaluation_system_message.jinja
@@ -1,5 +1,14 @@
 You are an expert technical recruiter evaluating resumes. Provide accurate, objective evaluations based on the given criteria.
 
+## TARGET ROLE & PRIORITIES
+Target Role: {{ experience_level_name }}
+Role Priorities:
+{% for item in priorities %}
+- {{ item }}
+{% endfor %}
+
+Adjust your expectations for what constitutes a "good" score based on the target role and priorities above. The maximum total score is always 120 points, but the evidence and reasoning must reflect the target role.
+
 **CRITICAL: You are NOT writing a resume summary. You are SCORING a resume for a job application.**
 
 **CRITICAL FAIRNESS REQUIREMENTS:**
@@ -20,9 +29,9 @@ You are an expert technical recruiter evaluating resumes. Provide accurate, obje
 
 **MANDATORY: You MUST always fill ALL FOUR categories: open_source, self_projects, production, technical_skills.**
 
-- For open_source: Analyze all open source contributions, GitHub/GitLab activity, and community involvement. Look for Google Summer of Code (GSoC) and Girl Script Summer of Code participation. **CRITICAL**: Having personal GitHub repositories does NOT constitute open source contribution. True open source contribution means contributing to OTHER people's projects or the broader community. Personal repositories should receive low scores (5-10 points) unless they demonstrate exceptional complexity or community impact. **CRITICAL**: Hacktoberfest participation alone (without evidence of contributions to significant projects) should receive 5-8 points maximum. **MANDATORY DEDUCTION**: If the only open source activity is Hacktoberfest participation without evidence of contributions to significant projects, apply a 3-5 point deduction to the open source score. **CRITICAL FOR KEY STRENGTHS**: Do NOT list "open source projects" or "active open source contributions" as key strengths unless the candidate has made actual contributions to other people's projects (not just personal repositories). **MANDATORY**: If the evidence states "No evidence of significant open source contributions" or "no demonstrable open source activity beyond personal GitHub projects", then open source should NOT be listed as a key strength. **NEW**: When GitHub data is provided, check the 'project_type' field - projects with 'open_source' type (multiple contributors) should receive higher scores than 'self_project' type (single contributor).
+- For open_source: Analyze all open source contributions, GitHub/GitLab activity, and community involvement. Look for Google Summer of Code (GSoC) and Girl Script Summer of Code participation. **CRITICAL**: Having personal GitHub repositories does NOT constitute open source contribution. True open source contribution means contributing to OTHER people's projects or the broader community. Personal repositories should receive low scores ({{ (max_weights.open_source * 0.15) | int }}-{{ (max_weights.open_source * 0.4) | int - 1 }} points) unless they demonstrate exceptional complexity or community impact. **CRITICAL**: Hacktoberfest participation alone (without evidence of contributions to significant projects) should receive {{ (max_weights.open_source * 0.15) | int }}-{{ (max_weights.open_source * 0.25) | int }} points maximum. **MANDATORY DEDUCTION**: If the only open source activity is Hacktoberfest participation without evidence of contributions to significant projects, apply a 3-5 point deduction to the open source score. **CRITICAL FOR KEY STRENGTHS**: Do NOT list "open source projects" or "active open source contributions" as key strengths unless the candidate has made actual contributions to other people's projects (not just personal repositories). **MANDATORY**: If the evidence states "No evidence of significant open source contributions" or "no demonstrable open source activity beyond personal GitHub projects", then open source should NOT be listed as a key strength. **NEW**: When GitHub data is provided, check the 'project_type' field - projects with 'open_source' type (multiple contributors) should receive higher scores than 'self_project' type (single contributor).
 
-- For self_projects: Analyze the 'projects' section and any personal, hackathon, or side projects. **CRITICAL PROJECT EVALUATION**: Assess project complexity and impact, not just quantity. Simple tutorial projects (todo lists, calculators, basic CRUD apps, weather apps, note-taking apps) should receive LOW SCORES (1-9 points) or trigger deductions. **MANDATORY: For self projects that are basic CRUD applications, give NO POINTS (0 points).** Complex projects with real-world impact, advanced architecture, or contributions to popular open source projects should receive HIGH SCORES (20-30 points). Apply 2-5 point deductions for resumes with only simple tutorial projects. **PROJECT LINK REQUIREMENTS**: Projects without active links, GitHub repositories, or live demos should receive significantly lower scores. Apply 3-5 point deductions for each project without any GitHub link, live demo, or active URL. Projects with only GitHub links (no live demo) should receive 2-3 point deductions. Projects with broken or inactive links should receive 1-2 point deductions. Projects without links are difficult to verify and demonstrate lack of transparency and professionalism. 
+- For self_projects: Analyze the 'projects' section and any personal, hackathon, or side projects. **CRITICAL PROJECT EVALUATION**: Assess project complexity and impact, not just quantity. Simple tutorial projects (todo lists, calculators, basic CRUD apps, weather apps, note-taking apps) should receive LOW SCORES (1-{{ (max_weights.self_projects * 0.35) | int - 1 }} points) or trigger deductions. **MANDATORY: For self projects that are basic CRUD applications, give NO POINTS (0 points).** Complex projects with real-world impact, advanced architecture, or contributions to popular open source projects should receive HIGH SCORES ({{ (max_weights.self_projects * 0.65) | int }}-{{ max_weights.self_projects }} points). Apply 2-5 point deductions for resumes with only simple tutorial projects. **PROJECT LINK REQUIREMENTS**: Projects without active links, GitHub repositories, or live demos should receive significantly lower scores. Apply 3-5 point deductions for each project without any GitHub link, live demo, or active URL. Projects with only GitHub links (no live demo) should receive 2-3 point deductions. Projects with broken or inactive links should receive 1-2 point deductions. Projects without links are difficult to verify and demonstrate lack of transparency and professionalism. 
 
 - For production: Analyze the 'work' and 'volunteer' sections for any real-world, internship, or production experience. If there is any work, internship, or volunteer experience, you MUST score this category and provide evidence. **SPECIAL CONSIDERATION FOR STARTUP EXPERIENCE**: Give extra points for founder roles, co-founder positions, or early-stage engineer roles (first 10-20 employees) at startups, as these demonstrate exceptional initiative, technical leadership, and ability to build products from scratch.
 
@@ -38,10 +47,10 @@ CRITICAL: You MUST respond with the EXACT JSON structure specified in the prompt
 - Evidence fields cannot be empty string
 - All category scores must be >= 0 (cannot be negative)
 - **CATEGORY SCORE LIMITS** (CANNOT be exceeded under any circumstances):
-  - open_source: 0-35 points (maximum 35)
-  - self_projects: 0-30 points (maximum 30)
-  - production: 0-25 points (maximum 25)
-  - technical_skills: 0-10 points (maximum 10)
+  - open_source: 0-{{ max_weights.open_source }} points (maximum {{ max_weights.open_source }})
+  - self_projects: 0-{{ max_weights.self_projects }} points (maximum {{ max_weights.self_projects }})
+  - production: 0-{{ max_weights.production }} points (maximum {{ max_weights.production }})
+  - technical_skills: 0-{{ max_weights.technical_skills }} points (maximum {{ max_weights.technical_skills }})
 - Bonus points total must be <= 20 (maximum 20 points)
 - **CRITICAL**: The total bonus points cannot exceed 20 points under any circumstances
 - **OVERALL SCORE LIMIT**: The total score (categories + bonus - deductions) cannot exceed 120 points

--- a/roles.py
+++ b/roles.py
@@ -1,0 +1,101 @@
+EXPERIENCE_LEVELS = {
+    "intern": "Software Intern",
+    "entry": "Entry Level",
+    "junior": "Junior (0-2 years)",
+    "mid": "Mid-level (2-5 years)",
+    "senior": "Senior (5+ years)",
+    "staff": "Staff Engineer",
+    "principal": "Principal Engineer",
+}
+
+ROLE_PRIORITIES = {
+    "intern": [
+        "Projects",
+        "Learning",
+        "Open Source",
+        "Hackathons",
+        "Research",
+        "Internships",
+    ],
+    "entry": ["Internships", "Projects", "Open Source", "Learning"],
+    "junior": [
+        "Internships",
+        "Projects",
+        "Production Work",
+        "Open Source",
+        "Ownership",
+    ],
+    "mid": [
+        "Production Impact",
+        "Architecture",
+        "Ownership",
+        "Mentoring",
+        "Cross-team Collaboration",
+    ],
+    "senior": [
+        "Technical Leadership",
+        "System Design",
+        "Business Impact",
+        "Scalability",
+        "Mentoring",
+        "Architecture Decisions",
+    ],
+    "staff": [
+        "Cross-organization Impact",
+        "Strategic Technical Direction",
+        "System Architecture",
+        "Leadership",
+        "Mentoring",
+    ],
+    "principal": [
+        "Company-wide Impact",
+        "Industry Leadership",
+        "Strategic Vision",
+        "Core Architecture",
+    ],
+}
+
+ROLE_MAX_SCORES = {
+    "intern": {
+        "open_source": 30,
+        "self_projects": 45,
+        "production": 10,
+        "technical_skills": 15,
+    },
+    "entry": {
+        "open_source": 25,
+        "self_projects": 35,
+        "production": 20,
+        "technical_skills": 20,
+    },
+    "junior": {
+        "open_source": 20,
+        "self_projects": 25,
+        "production": 35,
+        "technical_skills": 20,
+    },
+    "mid": {
+        "open_source": 15,
+        "self_projects": 20,
+        "production": 45,
+        "technical_skills": 20,
+    },
+    "senior": {
+        "open_source": 15,
+        "self_projects": 15,
+        "production": 45,
+        "technical_skills": 25,
+    },
+    "staff": {
+        "open_source": 15,
+        "self_projects": 15,
+        "production": 45,
+        "technical_skills": 25,
+    },
+    "principal": {
+        "open_source": 15,
+        "self_projects": 15,
+        "production": 45,
+        "technical_skills": 25,
+    },
+}

--- a/score.py
+++ b/score.py
@@ -76,18 +76,10 @@ def print_evaluation_results(
     print("-" * 60)
 
     if hasattr(evaluation, "scores") and evaluation.scores:
-        # Define category maximums
-        category_maxes = {
-            "open_source": 35,
-            "self_projects": 30,
-            "production": 25,
-            "technical_skills": 10,
-        }
-
         # Open Source
         if hasattr(evaluation.scores, "open_source") and evaluation.scores.open_source:
             os_score = evaluation.scores.open_source
-            capped_score = min(os_score.score, category_maxes["open_source"])
+            capped_score = min(os_score.score, os_score.max)
             print(f"🌐 Open Source:          {capped_score}/{os_score.max}")
             print(f"   Evidence: {os_score.evidence}")
             print()
@@ -98,7 +90,7 @@ def print_evaluation_results(
             and evaluation.scores.self_projects
         ):
             sp_score = evaluation.scores.self_projects
-            capped_score = min(sp_score.score, category_maxes["self_projects"])
+            capped_score = min(sp_score.score, sp_score.max)
             print(f"🚀 Self Projects:        {capped_score}/{sp_score.max}")
             print(f"   Evidence: {sp_score.evidence}")
             print()
@@ -106,7 +98,7 @@ def print_evaluation_results(
         # Production Experience
         if hasattr(evaluation.scores, "production") and evaluation.scores.production:
             prod_score = evaluation.scores.production
-            capped_score = min(prod_score.score, category_maxes["production"])
+            capped_score = min(prod_score.score, prod_score.max)
             print(f"🏢 Production Experience: {capped_score}/{prod_score.max}")
             print(f"   Evidence: {prod_score.evidence}")
             print()
@@ -117,7 +109,7 @@ def print_evaluation_results(
             and evaluation.scores.technical_skills
         ):
             tech_score = evaluation.scores.technical_skills
-            capped_score = min(tech_score.score, category_maxes["technical_skills"])
+            capped_score = min(tech_score.score, tech_score.max)
             print(f"💻 Technical Skills:     {capped_score}/{tech_score.max}")
             print(f"   Evidence: {tech_score.evidence}")
             print()

--- a/score.py
+++ b/score.py
@@ -160,7 +160,10 @@ def print_evaluation_results(
 
 
 def _evaluate_resume(
-    resume_data: JSONResume, github_data: dict = None, blog_data: dict = None
+    resume_data: JSONResume,
+    github_data: dict = None,
+    blog_data: dict = None,
+    experience_level: str = "intern",
 ) -> Optional[EvaluationData]:
     """Evaluate the resume using AI and display results."""
 
@@ -181,7 +184,9 @@ def _evaluate_resume(
         resume_text += blog_text
 
     # Evaluate the enhanced resume
-    evaluation_result = evaluator.evaluate_resume(resume_text)
+    evaluation_result = evaluator.evaluate_resume(
+        resume_text, experience_level=experience_level
+    )
 
     # print(evaluation_result)
 
@@ -211,7 +216,7 @@ def find_profile(profiles, network):
     )
 
 
-def main(pdf_path):
+def main(pdf_path, experience_level="intern"):
     # Create cache filename based on PDF path
     cache_filename = (
         f"cache/resumecache_{os.path.basename(pdf_path).replace('.pdf', '')}.json"
@@ -323,7 +328,9 @@ def main(pdf_path):
                     encoding="utf-8",
                 )
 
-    score = _evaluate_resume(resume_data, github_data)
+    score = _evaluate_resume(
+        resume_data, github_data, experience_level=experience_level
+    )
 
     # Get candidate name for display
     candidate_name = os.path.basename(pdf_path).replace(".pdf", "")
@@ -365,13 +372,22 @@ def main(pdf_path):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Usage: python score.py <pdf_path>")
-        exit(1)
-    pdf_path = sys.argv[1]
+    import argparse
+    from roles import EXPERIENCE_LEVELS
 
-    if not os.path.exists(pdf_path):
-        print(f"Error: File '{pdf_path}' does not exist.")
+    parser = argparse.ArgumentParser(description="Evaluate a resume from a PDF file.")
+    parser.add_argument("pdf_path", help="Path to the PDF resume file.")
+    parser.add_argument(
+        "-e", "--experience",
+        choices=list(EXPERIENCE_LEVELS.keys()),
+        default="intern",
+        help="Target experience level for evaluation.",
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.pdf_path):
+        print(f"Error: File '{args.pdf_path}' does not exist.")
         exit(1)
 
-    main(pdf_path)
+    main(args.pdf_path, experience_level=args.experience)


### PR DESCRIPTION
Replaces the static 35/30/25/10 point limits with a dynamic scoring algorithm that shifts the 100 base points depending on the `--e` target role.

Previously, Seniors were heavily penalized for lacking open source contributions, while Interns were unfairly capped on self projects. Now, `roles.py` defines the maximum point boundaries per role, and `evaluator.py` injects them as declarative Jinja math into the prompts, keeping the system 100% provider-agnostic. 

- Formatted with Black
- Added `DYNAMIC_SCORING.md` breakdown

**Testing Note & Request for Help:** I have run basic smoke tests on a single resume using the Gemini API (for the Intern and Senior roles), and the Jinja templating math successfully rendered and shifted the score bounds. However, my local machine cannot handle heavy workloads or run local Ollama models. 
Could a maintainer please help conduct multi-phase testing on this PR before merging? Specifically:
- [ ] Smoke testing against the default Ollama model
- [ ] Regression testing across a larger batch of resumes
- [ ] Validating the scoring output across the other untouched roles (Entry, Mid, Staff, etc.) and bigger models if required
