### PR TITLE
fix: strip URL fragments and trailing punctuation in extract_github_u…

### DIFF
--- a/github.py
+++ b/github.py
@@ -131,10 +131,14 @@ def extract_github_username(github_url: str) -> Optional[str]:
         match = re.search(pattern, github_url)
         if match:
             username = match.group(1)
-            # Remove query parameters if present (e.g., "?tab=repositories")
-            if "?" in username:
-                username = username.split("?", 1)[0]
-            return username
+            # Remove query parameters, fragments, or trailing path if present
+            # (e.g., "?tab=repositories", "#projects", "/repos")
+            username = re.split(r"[?#/]", username, maxsplit=1)[0]
+            # Strip any trailing punctuation carried over from prose
+            # (e.g., "github.com/octocat." or a trailing comma); GitHub
+            # usernames only contain alphanumerics and hyphens.
+            username = re.sub(r"[^A-Za-z0-9-]+$", "", username)
+            return username or None
     return None
 
 

--- a/username_extraction_checks.py
+++ b/username_extraction_checks.py
@@ -1,0 +1,70 @@
+"""Smoke tests for github.extract_github_username.
+
+Runs with the standard library only (no pytest dependency):
+
+    python -m unittest username_extraction_checks
+
+Named without the ``test_`` prefix because the repository's .gitignore
+excludes ``test_*.py``.
+"""
+
+import unittest
+
+from github import extract_github_username
+
+
+class ExtractGithubUsernameTests(unittest.TestCase):
+    def test_plain_url(self):
+        self.assertEqual(
+            extract_github_username("https://github.com/octocat"), "octocat"
+        )
+
+    def test_no_scheme(self):
+        self.assertEqual(extract_github_username("github.com/octocat"), "octocat")
+
+    def test_trailing_slash(self):
+        self.assertEqual(
+            extract_github_username("https://github.com/octocat/"), "octocat"
+        )
+
+    def test_query_parameters_stripped(self):
+        self.assertEqual(
+            extract_github_username("https://github.com/octocat?tab=repositories"),
+            "octocat",
+        )
+
+    def test_fragment_stripped(self):
+        # Regression for #335: "#projects" must not leak into the username.
+        self.assertEqual(
+            extract_github_username("https://github.com/octocat#projects"), "octocat"
+        )
+
+    def test_trailing_period_stripped(self):
+        # Regression for #335: URL pulled from prose ends with a period.
+        self.assertEqual(extract_github_username("github.com/octocat."), "octocat")
+
+    def test_trailing_comma_stripped(self):
+        # Regression for #335: URL pulled from prose ends with a comma.
+        self.assertEqual(extract_github_username("github.com/octocat,"), "octocat")
+
+    def test_at_handle(self):
+        self.assertEqual(extract_github_username("@octocat"), "octocat")
+
+    def test_bare_username(self):
+        self.assertEqual(extract_github_username("octocat"), "octocat")
+
+    def test_empty_input(self):
+        self.assertIsNone(extract_github_username(""))
+
+    def test_none_input(self):
+        self.assertIsNone(extract_github_username(None))
+
+    def test_hyphenated_username_preserved(self):
+        # Internal hyphens are valid and must survive.
+        self.assertEqual(
+            extract_github_username("https://github.com/oct-o-cat"), "oct-o-cat"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…sername

GitHub URLs pulled from resume prose are often followed by a #fragment, a trailing path, or punctuation (a period/comma). The parser only stripped ?query params, so these leaked into the username and 404'd the GitHub API, silently dropping all GitHub enrichment for the candidate.

Extend the existing cleanup to also cut at # and /, and trim trailing characters that are invalid in a GitHub username.

Adds stdlib unittest smoke tests.

Fixes #335