### PR TITLE
fix: resolve Windows UnicodeEncodeError and Python 3.14 Protobuf TypeError

### DIFF
--- a/score.py
+++ b/score.py
@@ -1,6 +1,17 @@
 import os
 import sys
 import json
+
+# Fix for Windows Console Unicode errors
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding='utf-8')
+    except AttributeError:
+        pass
+
+# Fix for Python 3.14 Protobuf TypeError
+os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
+
 import logging
 import csv
 from pdf import PDFHandler


### PR DESCRIPTION
This PR resolves two environment-specific execution crashes:
1. Reconfigures `sys.stdout` to use `utf-8` encoding to prevent `UnicodeEncodeError` when running the agent on Windows consoles.
2. Sets `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="python"` in the environment variables to prevent Protobuf metaclass `TypeError` exceptions on Python 3.14+.

Fixes #339 
