### PR TITLE
Fix JSON extraction failing on stray text before markdown fence

### DIFF
--- a/llm_utils.py
+++ b/llm_utils.py
@@ -28,12 +28,12 @@ def extract_json_from_response(response_text: str) -> str:
         if think_start != -1 and think_end != -1:
             response_text = response_text[:think_start] + response_text[think_end + 8 :]
 
-    # Remove leading ```json if present
-    if response_text.startswith("```json"):
-        response_text = response_text[7:]
-    # Remove trailing ``` if present
-    if response_text.endswith("```"):
-        response_text = response_text[:-3]
+    # Extract the JSON object itself, ignoring any wrapper text
+    # (markdown fences, a stray "json" label, etc.) before/after it
+    start = response_text.find("{")
+    end = response_text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        return response_text[start : end + 1]
     return response_text
 
 


### PR DESCRIPTION
## Summary
- Ollama sometimes prefixes the response with a bare `json` word before the ` ```json ` fence
- `extract_json_from_response`'s `startswith("```json")` / `endswith("```")` check doesn't strip that stray prefix, so `json.loads` chokes on the leftover text with `Expecting value: line 1 column 1 (char 0)`
- Replaced the prefix/suffix matching in `llm_utils.py` with slicing between the first `{` and last `}`, which is robust to any wrapper text (fences, stray labels, whitespace) around the JSON object

## Test plan
- [x] Repro'd with a payload shaped like the failing log (`"json\n```json\n{...}\n```\n"`) and confirmed `extract_json_from_response` now returns clean JSON that `json.loads` parses
- [ ] Reviewer: re-run resume evaluation against Ollama to confirm the original traceback no longer occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)