### PR TITLE
fix: trim responses after think blocks

### DIFF
--- a/llm_utils.py
+++ b/llm_utils.py
@@ -27,6 +27,7 @@ def extract_json_from_response(response_text: str) -> str:
         think_end = response_text.find("</think>")
         if think_start != -1 and think_end != -1:
             response_text = response_text[:think_start] + response_text[think_end + 8 :]
+            response_text = response_text.strip()
 
     # Remove leading ```json if present
     if response_text.startswith("```json"):

--- a/tests/llm_utils_test.py
+++ b/tests/llm_utils_test.py
@@ -1,0 +1,50 @@
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def load_extract_json_from_response():
+    models = types.ModuleType("models")
+    models.ModelProvider = types.SimpleNamespace(OLLAMA="ollama")
+    models.OllamaProvider = object
+    models.GeminiProvider = object
+
+    prompt = types.ModuleType("prompt")
+    prompt.MODEL_PROVIDER_MAPPING = {}
+    prompt.GEMINI_API_KEY = None
+
+    module_path = Path(__file__).parents[1] / "llm_utils.py"
+    spec = importlib.util.spec_from_file_location("llm_utils", module_path)
+    module = importlib.util.module_from_spec(spec)
+
+    with patch.dict(sys.modules, {"models": models, "prompt": prompt}):
+        spec.loader.exec_module(module)
+
+    return module.extract_json_from_response
+
+
+extract_json_from_response = load_extract_json_from_response()
+
+
+class ExtractJsonFromResponseTests(unittest.TestCase):
+    def test_supported_response_shapes_are_valid_json(self):
+        responses = {
+            "plain JSON": '{"ok": true}',
+            "fenced JSON": '```json\n{"ok": true}\n```',
+            "think block then fenced JSON": (
+                '<think>reasoning</think>\n```json\n{"ok": true}\n```'
+            ),
+        }
+
+        for name, response in responses.items():
+            with self.subTest(name=name):
+                cleaned = extract_json_from_response(response)
+                self.assertEqual(json.loads(cleaned), {"ok": True})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #345.

## Summary

Trim the response again after removing a complete `<think>...</think>` block. This lets the existing Markdown-fence cleanup recognize JSON fences exposed behind leading whitespace.

The correction affects the shared response normalizer used by resume evaluation, project generation, and PDF section extraction.

## Regression coverage

The new standard-library test covers:

- plain JSON
- directly fenced JSON
- a think block followed by fenced JSON

The third case raised `JSONDecodeError` before the one-line fix and passes afterward.

## Validation

- Focused regression: **1 passed**
- Full discovered local suite: **1 passed** (the repository had no existing tests)
- Black on both changed files: **passed**
- Python AST validation: **12/12 passed**
- `git diff --check`: **passed**

Real-provider and PDF pipeline smoke checks were not run because they require external models, documents, or credentials. No prompt, provider, dependency, API, or configuration behavior changes.