### PR TITLE
feat: Added support for GitHub Copilot SDK as LLM Provider

### DIFF
--- a/llm_utils.py
+++ b/llm_utils.py
@@ -4,7 +4,7 @@ Utility functions for LLM providers.
 
 import logging
 from typing import Any, Dict, Optional
-from models import ModelProvider, OllamaProvider, GeminiProvider
+from models import ModelProvider, OllamaProvider, GeminiProvider, CopilotProvider
 from prompt import MODEL_PROVIDER_MAPPING, GEMINI_API_KEY
 
 logger = logging.getLogger(__name__)
@@ -57,6 +57,9 @@ def initialize_llm_provider(model_name: str) -> Any:
         else:
             logger.info(f"🔄 Using Google Gemini API provider with model {model_name}")
             provider = GeminiProvider(api_key=GEMINI_API_KEY)
+    elif model_provider == ModelProvider.COPILOT:
+        logger.info(f"🔄 Using GitHub Copilot SDK provider with model {model_name}")
+        provider = CopilotProvider()
     else:
         logger.info(f"🔄 Using Ollama provider with model {model_name}")
     return provider

--- a/models.py
+++ b/models.py
@@ -396,7 +396,8 @@ class CopilotProvider:
     """GitHub Copilot SDK API provider implementation."""
 
     def __init__(self):
-        pass
+        import concurrent.futures
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
     def chat(
         self,
@@ -413,14 +414,33 @@ class CopilotProvider:
         from copilot.session import PermissionHandler
 
         async def run_chat():
-            system_msg = next((msg["content"] for msg in messages if msg["role"] == "system"), "")
-            user_msg = next((msg["content"] for msg in messages if msg["role"] == "user"), "")
+            system_msgs = [msg["content"] for msg in messages if msg["role"] == "system"]
+            system_msg = "\n\n".join(system_msgs)
             
+            non_system_msgs = [msg for msg in messages if msg["role"] != "system"]
+            if len(non_system_msgs) == 1 and non_system_msgs[0]["role"] == "user":
+                user_msg = non_system_msgs[0]["content"]
+            else:
+                conversation = []
+                for msg in non_system_msgs:
+                    role = "User" if msg["role"] == "user" else "Assistant"
+                    conversation.append(f"{role}:\n{msg['content']}")
+                user_msg = "\n\n".join(conversation)
+            
+            if kwargs.get("format") == "json":
+                json_instruction = "You must output the result in strictly valid JSON format."
+                system_msg = f"{system_msg}\n\n{json_instruction}" if system_msg else json_instruction
+
             async with CopilotClient() as client:
                 session_params = {
                     "model": model,
-                    "on_permission_request": PermissionHandler.approve_all,
                 }
+                if "stream" in kwargs:
+                    session_params["streaming"] = kwargs["stream"]
+                if "on_permission_request" in kwargs:
+                    session_params["on_permission_request"] = kwargs["on_permission_request"]
+                elif options and "on_permission_request" in options:
+                    session_params["on_permission_request"] = options["on_permission_request"]
                 if system_msg:
                     session_params["system_message"] = {
                         "mode": "replace",
@@ -438,7 +458,8 @@ class CopilotProvider:
                             if event.data.content:
                                 response_content.append(event.data.content)
                         elif isinstance(event.data, SessionErrorData):
-                            session_error = getattr(event.data, "error", str(event.data))
+                            session_error = getattr(event.data, "error", event.data)
+                            done.set()
                         elif isinstance(event.data, SessionIdleData):
                             done.set()
 
@@ -447,13 +468,14 @@ class CopilotProvider:
                     await done.wait()
                     
                     if session_error:
+                        if isinstance(session_error, Exception):
+                            raise session_error
                         raise RuntimeError(f"Copilot SDK Error: {session_error}")
 
                     return "".join(response_content)
 
-        # Use a ThreadPoolExecutor as a clean sync-async bridge
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(asyncio.run, run_chat())
-            content = future.result()
+        # Use the class-level ThreadPoolExecutor as a clean sync-async bridge
+        future = self.executor.submit(asyncio.run, run_chat())
+        content = future.result()
             
         return {"message": {"role": "assistant", "content": content}}

--- a/models.py
+++ b/models.py
@@ -8,6 +8,7 @@ class ModelProvider(Enum):
 
     OLLAMA = "ollama"
     GEMINI = "gemini"
+    COPILOT = "copilot"
 
 
 @runtime_checkable
@@ -389,3 +390,70 @@ class GeminiProvider:
                     f"Retrying in {sleep_time}s..."
                 )
                 time.sleep(sleep_time)
+
+
+class CopilotProvider:
+    """GitHub Copilot SDK API provider implementation."""
+
+    def __init__(self):
+        pass
+
+    def chat(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        options: Dict[str, Any] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Send a chat request to GitHub Copilot SDK."""
+        import asyncio
+        import concurrent.futures
+        from copilot import CopilotClient
+        from copilot.session_events import AssistantMessageData, SessionIdleData, SessionErrorData
+        from copilot.session import PermissionHandler
+
+        async def run_chat():
+            system_msg = next((msg["content"] for msg in messages if msg["role"] == "system"), "")
+            user_msg = next((msg["content"] for msg in messages if msg["role"] == "user"), "")
+            
+            async with CopilotClient() as client:
+                session_params = {
+                    "model": model,
+                    "on_permission_request": PermissionHandler.approve_all,
+                }
+                if system_msg:
+                    session_params["system_message"] = {
+                        "mode": "replace",
+                        "content": system_msg
+                    }
+                
+                async with await client.create_session(**session_params) as session:
+                    done = asyncio.Event()
+                    response_content = []
+                    session_error = None
+
+                    def on_event(event):
+                        nonlocal session_error
+                        if isinstance(event.data, AssistantMessageData):
+                            if event.data.content:
+                                response_content.append(event.data.content)
+                        elif isinstance(event.data, SessionErrorData):
+                            session_error = getattr(event.data, "error", str(event.data))
+                        elif isinstance(event.data, SessionIdleData):
+                            done.set()
+
+                    session.on(on_event)
+                    await session.send(user_msg)
+                    await done.wait()
+                    
+                    if session_error:
+                        raise RuntimeError(f"Copilot SDK Error: {session_error}")
+
+                    return "".join(response_content)
+
+        # Use a ThreadPoolExecutor as a clean sync-async bridge
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(asyncio.run, run_chat())
+            content = future.result()
+            
+        return {"message": {"role": "assistant", "content": content}}

--- a/prompt.py
+++ b/prompt.py
@@ -41,6 +41,15 @@ MODEL_PARAMETERS = {
     "gemini-2.5-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
+    # GitHub Copilot models
+    "gpt-5.5": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-5.6-luna": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-5.6-sol": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-5.6-terra": {"temperature": 0.1, "top_p": 0.9},
+    "claude-sonnet-5": {"temperature": 0.1, "top_p": 0.9},
+    "claude-opus-4.8": {"temperature": 0.1, "top_p": 0.9},
+    "claude-fable-5": {"temperature": 0.1, "top_p": 0.9},
+    "mai-code-1-flash": {"temperature": 0.1, "top_p": 0.9},
 }
 
 # Model provider mapping
@@ -61,6 +70,15 @@ MODEL_PROVIDER_MAPPING = {
     "gemini-2.5-pro": ModelProvider.GEMINI,
     "gemini-3.5-flash": ModelProvider.GEMINI,
     "gemini-3.1-flash-lite": ModelProvider.GEMINI,
+    # GitHub Copilot models
+    "gpt-5.5": ModelProvider.COPILOT,
+    "gpt-5.6-luna": ModelProvider.COPILOT,
+    "gpt-5.6-sol": ModelProvider.COPILOT,
+    "gpt-5.6-terra": ModelProvider.COPILOT,
+    "claude-sonnet-5": ModelProvider.COPILOT,
+    "claude-opus-4.8": ModelProvider.COPILOT,
+    "claude-fable-5": ModelProvider.COPILOT,
+    "mai-code-1-flash": ModelProvider.COPILOT,
 }
 
 # Get API keys from environment

--- a/prompt.py
+++ b/prompt.py
@@ -42,14 +42,14 @@ MODEL_PARAMETERS = {
     "gemini-3.5-flash": {"temperature": 0.1, "top_p": 0.9},
     "gemini-3.1-flash-lite": {"temperature": 0.1, "top_p": 0.9},
     # GitHub Copilot models
-    "gpt-5.5": {"temperature": 0.1, "top_p": 0.9},
-    "gpt-5.6-luna": {"temperature": 0.1, "top_p": 0.9},
-    "gpt-5.6-sol": {"temperature": 0.1, "top_p": 0.9},
-    "gpt-5.6-terra": {"temperature": 0.1, "top_p": 0.9},
-    "claude-sonnet-5": {"temperature": 0.1, "top_p": 0.9},
-    "claude-opus-4.8": {"temperature": 0.1, "top_p": 0.9},
-    "claude-fable-5": {"temperature": 0.1, "top_p": 0.9},
-    "mai-code-1-flash": {"temperature": 0.1, "top_p": 0.9},
+    "gpt-5.5": {},
+    "gpt-5.6-luna": {},
+    "gpt-5.6-sol": {},
+    "gpt-5.6-terra": {},
+    "claude-sonnet-5": {},
+    "claude-opus-4.8": {},
+    "claude-fable-5": {},
+    "mai-code-1-flash": {},
 }
 
 # Model provider mapping

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Jinja2==3.1.6
 google-generativeai==0.4.0
 python-dotenv==1.0.1
 black==25.9.0
+github-copilot-sdk==1.0.6


### PR DESCRIPTION
# Description

This PR introduces the **GitHub Copilot SDK** as a supported LLM Provider, allowing developers with active Copilot CLI subscriptions to leverage industry-leading models seamlessly. 

Closes #343 

## Changes Made
- **Dependency Addition**: Added `github-copilot-sdk` to `requirements.txt`.
- **`CopilotProvider` Implementation**: Created a new provider in `models.py` bridging the Copilot Python SDK.
- **Sync-Async Bridge**: Implemented a `ThreadPoolExecutor` in `CopilotProvider` to gracefully wrap the Copilot SDK's native asynchronous event loop inside `hiring-agent`'s synchronous provider interface. This prevents any event loop collision issues.
- **Error Bubbling**: Explicitly intercepts and raises `SessionErrorData` to ensure SDK issues (like unauthenticated states) properly bubble up to the pipeline rather than failing silently.
- **Model Support Updates**: Updated `prompt.py` to map the most recent Copilot-supported models.

### Prompts Configuration (Before / After)

**Before:**
```python
# Model provider mapping
MODEL_PROVIDER_MAPPING = {
    # Google Gemini models
    "gemini-1.5-pro": ModelProvider.GEMINI,
    "gemini-1.5-flash": ModelProvider.GEMINI,
    # ...
}
**After**
# Model provider mapping
MODEL_PROVIDER_MAPPING = {
    # Google Gemini models
    "gemini-1.5-pro": ModelProvider.GEMINI,
    # ...
    
    # GitHub Copilot models
    "gpt-5.5": ModelProvider.COPILOT,
    "gpt-5.6-luna": ModelProvider.COPILOT,
    "gpt-5.6-sol": ModelProvider.COPILOT,
    "gpt-5.6-terra": ModelProvider.COPILOT,
    "claude-sonnet-5": ModelProvider.COPILOT,
    "claude-opus-4.8": ModelProvider.COPILOT,
    "claude-fable-5": ModelProvider.COPILOT,
    "mai-code-1-flash": ModelProvider.COPILOT,
}