### PR TITLE
Add golden dataset & evaluation framework for agent performance (#308)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,25 @@ What happens:
 
 ---
 
+## Evaluation
+
+To measure how well the agent's scores agree with human judgment — and to
+compare models or catch regressions — use the golden-dataset framework:
+
+```bash
+python -m evals.run_eval                 # score the golden dataset, print metrics
+python -m evals.run_eval --repeat 3      # average runs to smooth LLM noise
+```
+
+See [`evals/README.md`](./evals/README.md) for the dataset format, metrics, and
+how to add cases. The framework's own tests run offline (no LLM required):
+
+```bash
+python -m pytest evals/tests
+```
+
+---
+
 ## Directory layout
 
 ```text
@@ -246,7 +265,9 @@ What happens:
 ├── pymupdf_rag.py
 ├── requirements.txt
 ├── score.py
-└── transform.py
+├── score_utils.py
+├── transform.py
+└── evals/                 # golden dataset + evaluation framework (see evals/README.md)
 ```
 
 ---

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,112 @@
+# Golden Dataset & Evaluation Framework
+
+A golden dataset of labeled résumés plus a runner that measures how well the
+hiring agent's scores agree with human judgment. Use it to compare models
+(e.g. `gemma3:4b` vs. `gemini-2.0-flash`) or to catch regressions after changing
+prompts.
+
+Addresses [issue #308](https://github.com/interviewstreet/hiring-agent/issues/308).
+
+## What it measures
+
+The dataset feeds the agent at the **evaluator boundary**: each case supplies a
+structured résumé (`JSONResume` shape) and optional GitHub data, and the runner
+compares the evaluator's output against human-assigned **bands** and
+**per-category tolerance ranges**. This isolates *scoring quality* — the part
+that changes when you swap models — without the noise of PDF parsing, extraction,
+or live GitHub calls.
+
+All committed résumés are **synthetic** (no PII, no real GitHub accounts).
+
+## Layout
+
+```
+evals/
+├── golden/            # one JSON file per résumé case
+├── metrics.py         # pure metric functions (offline, no deps)
+├── run_eval.py        # loads golden/, runs the agent, reports metrics
+└── tests/             # offline unit + smoke + dataset-integrity tests
+```
+
+## Running
+
+From the repo root, with an LLM backend configured (see the main README):
+
+```bash
+# Run the whole dataset with the default backend
+python -m evals.run_eval
+
+# Average 3 runs per case to smooth LLM non-determinism, and save a report
+python -m evals.run_eval --repeat 3 --out report.json
+
+# Run a single case
+python -m evals.run_eval --filter strong_oss_gsoc
+
+# Compare a different model — just change the environment
+LLM_PROVIDER=gemini DEFAULT_MODEL=gemini-2.0-flash python -m evals.run_eval
+
+# Use as a regression gate (non-zero exit if band accuracy drops below 0.7)
+python -m evals.run_eval --min-band-accuracy 0.7
+```
+
+The JSON report is stamped with the provider, model, case count, repeat count,
+and timestamp, so reports from different models are directly comparable.
+
+## Case format
+
+One JSON file per résumé in `golden/`:
+
+```jsonc
+{
+  "id": "strong_oss_gsoc",
+  "description": "Short human-readable summary of the case.",
+  "resume": { /* a JSONResume object — same shape models.JSONResume expects */ },
+  "github": null,                      // or a synthetic github_data dict
+  "labels": {
+    "overall_band": "strong",          // "strong" | "medium" | "weak"
+    "categories": {
+      "open_source":      { "min": 26, "max": 35 },
+      "self_projects":    { "min": 18, "max": 30 },
+      "production":       { "min": 14, "max": 25 },
+      "technical_skills": { "min": 7,  "max": 10 }
+    },
+    "rationale": "Why a human assigned these ranges — kept for auditability."
+  }
+}
+```
+
+- Category ranges are inclusive `[min, max]` and must sit within the category
+  caps (open_source ≤ 35, self_projects ≤ 30, production ≤ 25, technical_skills ≤ 10).
+- The **band** is bucketed from the agent's total score using the default
+  thresholds **strong ≥ 70, medium ≥ 40, weak < 40** (on the 0–120 total scale).
+
+## Adding a case
+
+1. Copy an existing file in `golden/` and give it a unique `id`.
+2. Write a synthetic résumé and assign category ranges + an overall band, with a
+   `rationale`. Keep ranges wide enough to tolerate LLM noise but tight enough to
+   be meaningful.
+3. Run the integrity tests — they check the schema, that ranges are within caps,
+   and that your ranges are internally consistent with the declared band:
+
+   ```bash
+   python -m pytest evals/tests/test_golden_dataset.py
+   ```
+
+## Metrics reported
+
+- **Band exact accuracy** — fraction of cases whose predicted band matches the gold band.
+- **Band within-one rate** — treats bands as ordinal (weak→strong is worse than weak→medium).
+- **Overall / per-category within-range rate** — fraction of category scores landing inside the tolerance range.
+- **Per-category bias** (mean signed error to the range midpoint) — reveals systematic over/under-scoring.
+- **Per-category mean-miss** — average distance outside the range when a score misses.
+- **Spearman rank correlation** — does the agent order candidates the way humans do?
+- **Stability** (with `--repeat > 1`) — standard deviation of the total across repeats.
+
+## Limitations / next steps
+
+- Measures the evaluator only, not PDF extraction or GitHub enrichment. A
+  full-pipeline (PDF-in) mode is a natural follow-up.
+- The seed set is small (9 cases) and intended to be grown by contributors.
+- Requires a running LLM backend; the tests, however, run fully offline via a
+  stubbed evaluator.

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Golden-dataset evaluation framework for the hiring agent (issue #308)."""

--- a/evals/golden/medium_balanced.json
+++ b/evals/golden/medium_balanced.json
@@ -1,0 +1,59 @@
+{
+  "id": "medium_balanced",
+  "description": "Solid but not standout: one internship, a couple of real projects, some GitHub activity.",
+  "resume": {
+    "basics": {
+      "name": "Candidate D",
+      "summary": "CS student with internship experience and a few personal projects.",
+      "url": "https://candidate-d.dev",
+      "profiles": [
+        {"network": "GitHub", "username": "candidate-d", "url": "https://github.com/candidate-d"},
+        {"network": "LinkedIn", "username": "candidate-d", "url": "https://linkedin.com/in/candidate-d"}
+      ]
+    },
+    "work": [
+      {
+        "name": "Local Software Co.",
+        "position": "Software Intern",
+        "startDate": "2025-06",
+        "endDate": "2025-08",
+        "summary": "Worked on internal web tooling used by the support team.",
+        "highlights": ["Added features to an internal admin dashboard", "Wrote unit tests for existing endpoints"]
+      }
+    ],
+    "education": [
+      {"institution": "State University", "area": "Computer Science", "studyType": "B.Tech", "startDate": "2022-08", "endDate": "2026-05"}
+    ],
+    "skills": [
+      {"name": "Languages", "keywords": ["Java", "Python", "JavaScript"]},
+      {"name": "Web", "keywords": ["Spring Boot", "React", "MySQL"]}
+    ],
+    "projects": [
+      {
+        "name": "expense-tracker",
+        "description": "Full-stack expense tracker with auth and charts; deployed live demo.",
+        "url": "https://github.com/candidate-d/expense-tracker",
+        "highlights": ["User auth and persistent storage", "Deployed with a working demo link"],
+        "technologies": ["React", "Spring Boot", "MySQL"]
+      },
+      {
+        "name": "small OSS fix",
+        "description": "One merged PR fixing documentation in a mid-sized open-source library.",
+        "url": "https://github.com/some-org/some-lib/pull/123",
+        "highlights": ["1 merged PR (docs/typo fix)"],
+        "technologies": ["Markdown"]
+      }
+    ]
+  },
+  "github": null,
+  "labels": {
+    "overall_band": "medium",
+    "categories": {
+      "open_source": {"min": 6, "max": 16},
+      "self_projects": {"min": 12, "max": 22},
+      "production": {"min": 10, "max": 20},
+      "technical_skills": {"min": 5, "max": 9}
+    },
+    "rationale": "One real internship and a deployed full-stack project are solid but not exceptional; the single docs PR is minimal open-source signal. Totals land squarely in the medium band."
+  }
+}

--- a/evals/golden/medium_oss_only_no_prod.json
+++ b/evals/golden/medium_oss_only_no_prod.json
@@ -1,0 +1,46 @@
+{
+  "id": "medium_oss_only_no_prod",
+  "description": "Some real open-source contributions but weak personal projects and no work experience.",
+  "resume": {
+    "basics": {
+      "name": "Candidate F",
+      "summary": "Contributes small fixes to open-source projects while studying.",
+      "profiles": [
+        {"network": "GitHub", "username": "candidate-f", "url": "https://github.com/candidate-f"}
+      ]
+    },
+    "education": [
+      {"institution": "State University", "area": "Computer Science", "studyType": "B.Sc", "startDate": "2023-08", "endDate": "2027-05"}
+    ],
+    "skills": [
+      {"name": "Languages", "keywords": ["Python", "Go"]}
+    ],
+    "projects": [
+      {
+        "name": "requests (upstream)",
+        "description": "3 merged PRs fixing bugs and improving tests in a popular library.",
+        "url": "https://github.com/psf/requests/pulls?q=author:candidate-f",
+        "highlights": ["3 merged PRs into a 50k+ star project"],
+        "technologies": ["Python"]
+      },
+      {
+        "name": "todo-cli",
+        "description": "A simple command-line todo list.",
+        "url": "https://github.com/candidate-f/todo-cli",
+        "highlights": ["Basic CRUD in the terminal"],
+        "technologies": ["Go"]
+      }
+    ]
+  },
+  "github": null,
+  "labels": {
+    "overall_band": "medium",
+    "categories": {
+      "open_source": {"min": 18, "max": 28},
+      "self_projects": {"min": 4, "max": 14},
+      "production": {"min": 0, "max": 8},
+      "technical_skills": {"min": 5, "max": 9}
+    },
+    "rationale": "Real merged PRs to a popular project give meaningful open_source credit, but personal projects are trivial (a todo CLI) and there is no production experience. The open-source strength alone lifts the total into the low-medium band."
+  }
+}

--- a/evals/golden/medium_projects_no_prod.json
+++ b/evals/golden/medium_projects_no_prod.json
@@ -1,0 +1,55 @@
+{
+  "id": "medium_projects_no_prod",
+  "description": "Strong self-projects but no production/work experience and little open source.",
+  "resume": {
+    "basics": {
+      "name": "Candidate E",
+      "summary": "Self-taught builder with several substantial personal projects.",
+      "url": "https://candidate-e.dev",
+      "profiles": [
+        {"network": "GitHub", "username": "candidate-e", "url": "https://github.com/candidate-e"}
+      ]
+    },
+    "education": [
+      {"institution": "State University", "area": "Information Technology", "studyType": "B.Tech", "startDate": "2023-08", "endDate": "2027-05"}
+    ],
+    "skills": [
+      {"name": "Languages", "keywords": ["Python", "JavaScript", "TypeScript"]},
+      {"name": "ML/Web", "keywords": ["PyTorch", "FastAPI", "Next.js"]}
+    ],
+    "projects": [
+      {
+        "name": "semantic-notes",
+        "description": "Note app with local embedding search; non-trivial architecture, live demo.",
+        "url": "https://github.com/candidate-e/semantic-notes",
+        "highlights": ["Vector search over notes", "Working deployed demo", "Documented"],
+        "technologies": ["Next.js", "FastAPI", "SQLite"]
+      },
+      {
+        "name": "mini-torch",
+        "description": "A small autograd engine reimplementing backprop from scratch.",
+        "url": "https://github.com/candidate-e/mini-torch",
+        "highlights": ["Reverse-mode autodiff", "Trains a small MLP on MNIST"],
+        "technologies": ["Python"]
+      },
+      {
+        "name": "chat-rooms",
+        "description": "Real-time chat with WebSockets and presence.",
+        "url": "https://github.com/candidate-e/chat-rooms",
+        "highlights": ["WebSocket rooms", "Redis-backed presence"],
+        "technologies": ["Node.js", "Redis"]
+      }
+    ]
+  },
+  "github": null,
+  "labels": {
+    "overall_band": "medium",
+    "categories": {
+      "open_source": {"min": 3, "max": 11},
+      "self_projects": {"min": 18, "max": 28},
+      "production": {"min": 0, "max": 6},
+      "technical_skills": {"min": 6, "max": 9}
+    },
+    "rationale": "Genuinely strong, complex self-projects with live demos push self_projects high, but the complete absence of work experience caps production near zero and there is essentially no contribution to others' projects. Net total is medium."
+  }
+}

--- a/evals/golden/strong_oss_gsoc.json
+++ b/evals/golden/strong_oss_gsoc.json
@@ -1,0 +1,62 @@
+{
+  "id": "strong_oss_gsoc",
+  "description": "GSoC contributor with merged PRs to a popular project and a production internship.",
+  "resume": {
+    "basics": {
+      "name": "Candidate A",
+      "summary": "CS undergraduate and open-source contributor focused on distributed systems.",
+      "url": "https://candidate-a.dev",
+      "profiles": [
+        {"network": "GitHub", "username": "candidate-a", "url": "https://github.com/candidate-a"},
+        {"network": "LinkedIn", "username": "candidate-a", "url": "https://linkedin.com/in/candidate-a"}
+      ]
+    },
+    "work": [
+      {
+        "name": "Acme Cloud",
+        "position": "Software Engineering Intern",
+        "startDate": "2025-05",
+        "endDate": "2025-08",
+        "summary": "Backend intern on the billing platform serving production traffic.",
+        "highlights": [
+          "Shipped a rate-limiting service handling 5k req/s in production",
+          "Reduced p99 latency of the invoice API by 40%"
+        ]
+      }
+    ],
+    "education": [
+      {"institution": "State University", "area": "Computer Science", "studyType": "B.Tech", "startDate": "2022-08", "endDate": "2026-05"}
+    ],
+    "skills": [
+      {"name": "Languages", "keywords": ["Go", "Python", "Rust", "SQL"]},
+      {"name": "Systems", "keywords": ["Kubernetes", "gRPC", "PostgreSQL", "Kafka"]}
+    ],
+    "projects": [
+      {
+        "name": "kubernetes (upstream)",
+        "description": "Google Summer of Code (GSoC) 2025 contributor: implemented a scheduler plugin, 6 PRs merged upstream.",
+        "url": "https://github.com/kubernetes/kubernetes/pulls?q=author:candidate-a",
+        "highlights": ["Merged 6 PRs into a 100k+ star project", "Authored the design doc reviewed by maintainers"],
+        "technologies": ["Go"]
+      },
+      {
+        "name": "raftlite",
+        "description": "A from-scratch Raft consensus library with a live demo cluster.",
+        "url": "https://github.com/candidate-a/raftlite",
+        "highlights": ["Leader election + log replication", "Fuzz-tested with 500+ generated scenarios"],
+        "technologies": ["Rust"]
+      }
+    ]
+  },
+  "github": null,
+  "labels": {
+    "overall_band": "strong",
+    "categories": {
+      "open_source": {"min": 26, "max": 35},
+      "self_projects": {"min": 18, "max": 30},
+      "production": {"min": 14, "max": 25},
+      "technical_skills": {"min": 7, "max": 10}
+    },
+    "rationale": "Merged PRs to a 100k-star project plus GSoC drives open_source high; a real production internship and a non-trivial systems project support the rest. Portfolio + LinkedIn justify bonus."
+  }
+}

--- a/evals/golden/strong_oss_heavy.json
+++ b/evals/golden/strong_oss_heavy.json
@@ -1,0 +1,66 @@
+{
+  "id": "strong_oss_heavy",
+  "description": "Prolific open-source contributor across several popular projects; limited formal work experience.",
+  "resume": {
+    "basics": {
+      "name": "Candidate C",
+      "summary": "Open-source maintainer contributing to widely used developer tooling.",
+      "url": "https://candidate-c.dev",
+      "profiles": [
+        {"network": "GitHub", "username": "candidate-c", "url": "https://github.com/candidate-c"},
+        {"network": "LinkedIn", "username": "candidate-c", "url": "https://linkedin.com/in/candidate-c"}
+      ]
+    },
+    "work": [
+      {
+        "name": "OpenDev Foundation",
+        "position": "Open Source Contributor (part-time)",
+        "startDate": "2024-06",
+        "endDate": "2026-01",
+        "summary": "Regular contributor and reviewer across multiple maintained repositories.",
+        "highlights": ["Triaged issues and reviewed community PRs", "Maintainer on one mid-sized project"]
+      }
+    ],
+    "education": [
+      {"institution": "State University", "area": "Computer Science", "studyType": "B.Tech", "startDate": "2022-08", "endDate": "2026-05"}
+    ],
+    "skills": [
+      {"name": "Languages", "keywords": ["Python", "C++", "TypeScript"]},
+      {"name": "Areas", "keywords": ["Compilers", "CLI tooling", "Testing infrastructure"]}
+    ],
+    "projects": [
+      {
+        "name": "pandas (upstream)",
+        "description": "12 merged PRs improving groupby performance and fixing correctness bugs.",
+        "url": "https://github.com/pandas-dev/pandas/pulls?q=author:candidate-c",
+        "highlights": ["Merged into a 40k+ star project", "Fixed a long-standing timezone bug"],
+        "technologies": ["Python", "Cython"]
+      },
+      {
+        "name": "ruff (upstream)",
+        "description": "Contributed new lint rules with tests; reviewed by maintainers.",
+        "url": "https://github.com/astral-sh/ruff/pulls?q=author:candidate-c",
+        "highlights": ["Added 3 lint rules", "20k+ star project"],
+        "technologies": ["Rust"]
+      },
+      {
+        "name": "devcli",
+        "description": "Own CLI tool that scaffolds project templates; live demo and docs.",
+        "url": "https://github.com/candidate-c/devcli",
+        "highlights": ["500+ stars", "Documented and tested"],
+        "technologies": ["TypeScript"]
+      }
+    ]
+  },
+  "github": null,
+  "labels": {
+    "overall_band": "strong",
+    "categories": {
+      "open_source": {"min": 28, "max": 35},
+      "self_projects": {"min": 16, "max": 28},
+      "production": {"min": 10, "max": 20},
+      "technical_skills": {"min": 8, "max": 10}
+    },
+    "rationale": "Sustained merged contributions to multiple popular projects put open_source near the top. Production is only part-time/OSS work so it caps lower, but strong self projects and technical breadth keep the total in the strong band."
+  }
+}

--- a/evals/golden/strong_startup_founder.json
+++ b/evals/golden/strong_startup_founder.json
@@ -1,0 +1,62 @@
+{
+  "id": "strong_startup_founder",
+  "description": "Startup co-founder / early engineer with strong shipped products; moderate OSS.",
+  "resume": {
+    "basics": {
+      "name": "Candidate B",
+      "summary": "Founding engineer who ships full-stack products end to end.",
+      "url": "https://candidate-b.dev",
+      "profiles": [
+        {"network": "GitHub", "username": "candidate-b", "url": "https://github.com/candidate-b"},
+        {"network": "LinkedIn", "username": "candidate-b", "url": "https://linkedin.com/in/candidate-b"}
+      ]
+    },
+    "work": [
+      {
+        "name": "Nimbus (seed-stage startup)",
+        "position": "Co-founder & Engineer",
+        "startDate": "2024-01",
+        "endDate": "2026-01",
+        "summary": "Co-founded a B2B analytics startup; built and operated the product in production.",
+        "highlights": [
+          "Built the full product from zero to 1,200 paying users",
+          "Owned infra, on-call, and the data pipeline in production"
+        ]
+      }
+    ],
+    "education": [
+      {"institution": "State University", "area": "Computer Science", "studyType": "B.Sc", "startDate": "2020-08", "endDate": "2024-05"}
+    ],
+    "skills": [
+      {"name": "Languages", "keywords": ["TypeScript", "Python", "Go"]},
+      {"name": "Stack", "keywords": ["React", "Node.js", "PostgreSQL", "AWS", "Docker"]}
+    ],
+    "projects": [
+      {
+        "name": "Nimbus Analytics",
+        "description": "Real-time analytics dashboard with auth, billing, and a streaming ingest pipeline.",
+        "url": "https://nimbus.example.com",
+        "highlights": ["Live product with paying customers", "Event pipeline processing millions of events/day"],
+        "technologies": ["TypeScript", "Kafka", "ClickHouse"]
+      },
+      {
+        "name": "openbilling",
+        "description": "Extracted the billing module as an open-source library; a few external contributors.",
+        "url": "https://github.com/candidate-b/openbilling",
+        "highlights": ["200+ stars", "Accepts community PRs"],
+        "technologies": ["TypeScript"]
+      }
+    ]
+  },
+  "github": null,
+  "labels": {
+    "overall_band": "strong",
+    "categories": {
+      "open_source": {"min": 12, "max": 24},
+      "self_projects": {"min": 22, "max": 30},
+      "production": {"min": 20, "max": 25},
+      "technical_skills": {"min": 8, "max": 10}
+    },
+    "rationale": "Co-founder shipping a live product with paying users maxes production and self_projects; open_source is moderate (one self-published library with light external activity). Founder role + portfolio + LinkedIn justify bonus, keeping the total firmly in the strong band."
+  }
+}

--- a/evals/golden/weak_selfrepos_only.json
+++ b/evals/golden/weak_selfrepos_only.json
@@ -1,0 +1,47 @@
+{
+  "id": "weak_selfrepos_only",
+  "description": "Only personal GitHub repos (no contributions to others); moderate personal projects, no work.",
+  "resume": {
+    "basics": {
+      "name": "Candidate I",
+      "summary": "Hobbyist developer with a handful of personal repositories.",
+      "profiles": [
+        {"network": "GitHub", "username": "candidate-i", "url": "https://github.com/candidate-i"}
+      ]
+    },
+    "education": [
+      {"institution": "State University", "area": "Computer Science", "studyType": "B.Tech", "startDate": "2023-08", "endDate": "2027-05"}
+    ],
+    "skills": [
+      {"name": "Languages", "keywords": ["Python", "JavaScript"]},
+      {"name": "Web", "keywords": ["Flask", "Bootstrap"]}
+    ],
+    "projects": [
+      {
+        "name": "portfolio-site",
+        "description": "Personal portfolio website.",
+        "url": "https://github.com/candidate-i/portfolio-site",
+        "highlights": ["Static site about myself"],
+        "technologies": ["HTML", "CSS"]
+      },
+      {
+        "name": "blog-engine",
+        "description": "A small personal blog engine with markdown posts; no external contributors.",
+        "url": "https://github.com/candidate-i/blog-engine",
+        "highlights": ["Markdown rendering", "Personal project, no live demo"],
+        "technologies": ["Flask"]
+      }
+    ]
+  },
+  "github": null,
+  "labels": {
+    "overall_band": "weak",
+    "categories": {
+      "open_source": {"min": 0, "max": 8},
+      "self_projects": {"min": 5, "max": 14},
+      "production": {"min": 0, "max": 6},
+      "technical_skills": {"min": 3, "max": 7}
+    },
+    "rationale": "Per the criteria, personal repositories alone do not constitute open-source contribution (open_source must stay <= 10). Projects are moderate at best and there is no work experience, so the total stays in the weak band despite an active GitHub presence."
+  }
+}

--- a/evals/golden/weak_sparse.json
+++ b/evals/golden/weak_sparse.json
@@ -1,0 +1,34 @@
+{
+  "id": "weak_sparse",
+  "description": "Very sparse resume: few skills, no projects with substance, no links, no experience.",
+  "resume": {
+    "basics": {
+      "name": "Candidate H",
+      "summary": "Aspiring programmer."
+    },
+    "education": [
+      {"institution": "State University", "area": "Computer Science", "studyType": "B.Sc", "startDate": "2024-08", "endDate": "2028-05"}
+    ],
+    "skills": [
+      {"name": "Languages", "keywords": ["C", "Python"]}
+    ],
+    "projects": [
+      {
+        "name": "College Assignment",
+        "description": "A classroom assignment implementing basic sorting algorithms.",
+        "highlights": ["Bubble sort and merge sort"]
+      }
+    ]
+  },
+  "github": null,
+  "labels": {
+    "overall_band": "weak",
+    "categories": {
+      "open_source": {"min": 0, "max": 4},
+      "self_projects": {"min": 0, "max": 8},
+      "production": {"min": 0, "max": 5},
+      "technical_skills": {"min": 1, "max": 5}
+    },
+    "rationale": "Almost no signal: a single classroom assignment, two languages, no GitHub profile, no links, no experience. Every category sits near the floor."
+  }
+}

--- a/evals/golden/weak_tutorial_projects.json
+++ b/evals/golden/weak_tutorial_projects.json
@@ -1,0 +1,50 @@
+{
+  "id": "weak_tutorial_projects",
+  "description": "Only tutorial-style projects (todo, calculator, weather), no OSS, no work experience.",
+  "resume": {
+    "basics": {
+      "name": "Candidate G",
+      "summary": "Beginner developer learning web development.",
+      "profiles": [
+        {"network": "GitHub", "username": "candidate-g", "url": "https://github.com/candidate-g"}
+      ]
+    },
+    "education": [
+      {"institution": "State University", "area": "Computer Applications", "studyType": "BCA", "startDate": "2024-08", "endDate": "2027-05"}
+    ],
+    "skills": [
+      {"name": "Languages", "keywords": ["HTML", "CSS", "JavaScript"]}
+    ],
+    "projects": [
+      {
+        "name": "Todo App",
+        "description": "A basic to-do list following a YouTube tutorial.",
+        "highlights": ["Add and remove tasks"],
+        "technologies": ["JavaScript"]
+      },
+      {
+        "name": "Calculator",
+        "description": "A simple calculator web page.",
+        "highlights": ["Basic arithmetic"],
+        "technologies": ["JavaScript"]
+      },
+      {
+        "name": "Weather App",
+        "description": "Shows weather using a public API; no live link.",
+        "highlights": ["Fetches from a weather API"],
+        "technologies": ["JavaScript"]
+      }
+    ]
+  },
+  "github": null,
+  "labels": {
+    "overall_band": "weak",
+    "categories": {
+      "open_source": {"min": 0, "max": 6},
+      "self_projects": {"min": 0, "max": 9},
+      "production": {"min": 0, "max": 5},
+      "technical_skills": {"min": 2, "max": 6}
+    },
+    "rationale": "All projects are generic tutorial clones with no links, no open-source contribution, and no work experience. Per the criteria these attract low self_projects scores and deductions, placing the candidate firmly in the weak band."
+  }
+}

--- a/evals/metrics.py
+++ b/evals/metrics.py
@@ -1,0 +1,173 @@
+"""Pure metric functions for the golden-dataset evaluation.
+
+Every function here is deterministic and free of I/O, LLM calls, and heavy
+dependencies, so the whole module is unit-testable offline.
+"""
+
+from typing import Dict, List, Optional, Sequence
+
+# Bands in ascending quality order. Used for ordinal comparisons.
+BAND_ORDER: Dict[str, int] = {"weak": 0, "medium": 1, "strong": 2}
+
+# Lower bound (inclusive) of each band on the 0..120 total scale.
+# strong >= 70, medium >= 40, else weak.
+DEFAULT_BAND_THRESHOLDS: Dict[str, float] = {"strong": 70, "medium": 40}
+
+
+def score_to_band(total: float, thresholds: Optional[Dict[str, float]] = None) -> str:
+    """Bucket a numeric total into a band using inclusive lower thresholds."""
+    t = thresholds or DEFAULT_BAND_THRESHOLDS
+    if total >= t["strong"]:
+        return "strong"
+    if total >= t["medium"]:
+        return "medium"
+    return "weak"
+
+
+def category_range_metrics(score: float, lo: float, hi: float) -> Dict[str, float]:
+    """Compare a single category score against its golden ``[lo, hi]`` range.
+
+    Returns whether it is within range, how far outside it fell (0 if inside),
+    and the signed error relative to the range midpoint (bias/calibration).
+    """
+    within = lo <= score <= hi
+    if score < lo:
+        out_of_range_distance = lo - score
+    elif score > hi:
+        out_of_range_distance = score - hi
+    else:
+        out_of_range_distance = 0.0
+    midpoint = (lo + hi) / 2.0
+    return {
+        "within": within,
+        "out_of_range_distance": out_of_range_distance,
+        "signed_midpoint_error": score - midpoint,
+    }
+
+
+def _rank(values: Sequence[float]) -> List[float]:
+    """Return fractional (average) ranks, handling ties."""
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        avg_rank = (i + j) / 2.0 + 1.0  # 1-based average rank for the tie group
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg_rank
+        i = j + 1
+    return ranks
+
+
+def _pearson(xs: Sequence[float], ys: Sequence[float]) -> Optional[float]:
+    n = len(xs)
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    cov = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    var_x = sum((x - mean_x) ** 2 for x in xs)
+    var_y = sum((y - mean_y) ** 2 for y in ys)
+    if var_x == 0 or var_y == 0:
+        return None
+    return cov / ((var_x**0.5) * (var_y**0.5))
+
+
+def spearman(xs: Sequence[float], ys: Sequence[float]) -> Optional[float]:
+    """Spearman rank correlation. Returns None when undefined (n < 2 or no variance)."""
+    if len(xs) != len(ys) or len(xs) < 2:
+        return None
+    r = _pearson(_rank(xs), _rank(ys))
+    if r is None:
+        return None
+    # Clamp and round away floating-point noise (e.g. 0.9999999999999998).
+    return round(max(-1.0, min(1.0, r)), 6)
+
+
+def summarize(cases: List[dict], thresholds: Optional[Dict[str, float]] = None) -> dict:
+    """Aggregate per-case results into summary agreement metrics.
+
+    Each item in ``cases`` is a dict with keys:
+      ``id``, ``gold_band``, ``gold_categories`` ({cat: {"min", "max"}}),
+      ``agent_total`` (float), ``agent_categories`` ({cat: score}).
+    """
+    thresholds = thresholds or DEFAULT_BAND_THRESHOLDS
+    n = len(cases)
+
+    predicted_bands: Dict[str, str] = {}
+    band_exact = 0
+    band_within_one = 0
+    confusion: Dict[str, Dict[str, int]] = {
+        g: {p: 0 for p in BAND_ORDER} for g in BAND_ORDER
+    }
+
+    # Per-category accumulators.
+    cat_names: List[str] = []
+    cat_within: Dict[str, int] = {}
+    cat_out_dist: Dict[str, float] = {}
+    cat_signed: Dict[str, float] = {}
+    cat_count: Dict[str, int] = {}
+
+    overall_within = 0
+    overall_cat_count = 0
+
+    totals_for_rank: List[float] = []
+    gold_ordinals_for_rank: List[float] = []
+
+    for case in cases:
+        pred = score_to_band(case["agent_total"], thresholds)
+        gold = case["gold_band"]
+        predicted_bands[case["id"]] = pred
+
+        confusion[gold][pred] += 1
+        if pred == gold:
+            band_exact += 1
+        if abs(BAND_ORDER[pred] - BAND_ORDER[gold]) <= 1:
+            band_within_one += 1
+
+        totals_for_rank.append(case["agent_total"])
+        gold_ordinals_for_rank.append(BAND_ORDER[gold])
+
+        for cat, rng in case["gold_categories"].items():
+            score = case["agent_categories"].get(cat)
+            if score is None:
+                continue
+            if cat not in cat_count:
+                cat_names.append(cat)
+                cat_within[cat] = 0
+                cat_out_dist[cat] = 0.0
+                cat_signed[cat] = 0.0
+                cat_count[cat] = 0
+            m = category_range_metrics(score, rng["min"], rng["max"])
+            cat_count[cat] += 1
+            if m["within"]:
+                cat_within[cat] += 1
+                overall_within += 1
+            cat_out_dist[cat] += m["out_of_range_distance"]
+            cat_signed[cat] += m["signed_midpoint_error"]
+            overall_cat_count += 1
+
+    categories = {
+        cat: {
+            "within_range_rate": cat_within[cat] / cat_count[cat],
+            "mean_out_of_range_distance": cat_out_dist[cat] / cat_count[cat],
+            "mean_signed_midpoint_error": cat_signed[cat] / cat_count[cat],
+            "n": cat_count[cat],
+        }
+        for cat in cat_names
+    }
+
+    return {
+        "n_cases": n,
+        "band": {
+            "exact_accuracy": band_exact / n if n else 0.0,
+            "within_one_rate": band_within_one / n if n else 0.0,
+            "confusion": confusion,
+        },
+        "categories": categories,
+        "overall_within_range_rate": (
+            overall_within / overall_cat_count if overall_cat_count else 0.0
+        ),
+        "rank_correlation_spearman": spearman(totals_for_rank, gold_ordinals_for_rank),
+        "predicted_bands": predicted_bands,
+    }

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -1,0 +1,300 @@
+"""Run the hiring agent over the golden dataset and report agreement metrics.
+
+Usage (from the repo root):
+
+    python -m evals.run_eval                        # run the seed dataset
+    python -m evals.run_eval --repeat 3 --out report.json
+    python -m evals.run_eval --filter strong_oss_heavy
+    LLM_PROVIDER=gemini DEFAULT_MODEL=gemini-2.0-flash python -m evals.run_eval
+
+The evaluator backend is whatever LLM_PROVIDER / DEFAULT_MODEL select, so
+comparing models is just an environment change.
+"""
+
+import argparse
+import glob
+import json
+import os
+import statistics
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Dict, List, Optional
+
+# Allow running as a plain script (python evals/run_eval.py) by putting the
+# repo root on the path.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from pydantic import BaseModel
+
+from models import JSONResume, EvaluationData
+from score_utils import aggregate_scores
+from evals import metrics
+
+DEFAULT_GOLDEN_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "golden")
+
+# evaluate_fn(resume, github) -> EvaluationData
+EvaluateFn = Callable[[JSONResume, Optional[dict]], EvaluationData]
+
+
+# --------------------------------------------------------------------------- #
+# Golden case schema
+# --------------------------------------------------------------------------- #
+
+
+class CategoryRange(BaseModel):
+    min: float
+    max: float
+
+
+class GoldenLabels(BaseModel):
+    overall_band: str  # "strong" | "medium" | "weak"
+    categories: Dict[str, CategoryRange]
+    rationale: Optional[str] = None
+
+
+class GoldenCase(BaseModel):
+    id: str
+    description: Optional[str] = None
+    resume: dict
+    github: Optional[dict] = None
+    labels: GoldenLabels
+
+
+def load_cases(golden_dir: str = DEFAULT_GOLDEN_DIR) -> List[GoldenCase]:
+    """Load and validate every ``*.json`` golden case in a directory."""
+    cases: List[GoldenCase] = []
+    for path in sorted(glob.glob(os.path.join(golden_dir, "*.json"))):
+        with open(path, encoding="utf-8") as f:
+            raw = json.load(f)
+        try:
+            cases.append(GoldenCase(**raw))
+        except Exception as e:  # noqa: BLE001 - surface which file is malformed
+            raise ValueError(f"Invalid golden case in {path}: {e}") from e
+    return cases
+
+
+# --------------------------------------------------------------------------- #
+# Default evaluator (lazily imports the heavy pipeline)
+# --------------------------------------------------------------------------- #
+
+
+def _default_evaluate_fn(resume: JSONResume, github: Optional[dict]) -> EvaluationData:
+    # Imported lazily so tests (which inject a fake) never pull PyMuPDF/ollama.
+    from score import _evaluate_resume
+
+    return _evaluate_resume(resume, github or {})
+
+
+# --------------------------------------------------------------------------- #
+# Runner
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _CaseRun:
+    totals: List[float]
+    per_category_runs: List[Dict[str, float]]
+
+
+def _evaluate_case(case: GoldenCase, evaluate_fn: EvaluateFn, repeat: int) -> _CaseRun:
+    resume = JSONResume(**case.resume)
+    totals: List[float] = []
+    per_category_runs: List[Dict[str, float]] = []
+    for _ in range(repeat):
+        evaluation = evaluate_fn(resume, case.github)
+        agg = aggregate_scores(evaluation)
+        totals.append(agg.total)
+        per_category_runs.append(agg.per_category)
+    return _CaseRun(totals=totals, per_category_runs=per_category_runs)
+
+
+def _mean_categories(runs: List[Dict[str, float]]) -> Dict[str, float]:
+    keys = runs[0].keys()
+    return {k: statistics.fmean(r[k] for r in runs) for k in keys}
+
+
+def run(
+    cases: List[GoldenCase],
+    evaluate_fn: EvaluateFn = _default_evaluate_fn,
+    repeat: int = 1,
+    thresholds: Optional[Dict[str, float]] = None,
+) -> dict:
+    """Score every case, then compute per-case and summary metrics."""
+    case_reports: List[dict] = []
+    summarize_input: List[dict] = []
+    stdevs: List[float] = []
+
+    for case in cases:
+        run_result = _evaluate_case(case, evaluate_fn, repeat)
+        mean_total = statistics.fmean(run_result.totals)
+        mean_categories = _mean_categories(run_result.per_category_runs)
+        total_stdev = (
+            statistics.stdev(run_result.totals) if len(run_result.totals) > 1 else 0.0
+        )
+        stdevs.append(total_stdev)
+
+        gold_categories = {
+            cat: {"min": rng.min, "max": rng.max}
+            for cat, rng in case.labels.categories.items()
+        }
+        predicted_band = metrics.score_to_band(mean_total, thresholds)
+
+        per_cat_detail = {}
+        all_within = True
+        for cat, rng in gold_categories.items():
+            score = mean_categories.get(cat)
+            if score is None:
+                continue
+            m = metrics.category_range_metrics(score, rng["min"], rng["max"])
+            per_cat_detail[cat] = {"score": score, **m}
+            all_within = all_within and m["within"]
+
+        case_reports.append(
+            {
+                "id": case.id,
+                "gold_band": case.labels.overall_band,
+                "predicted_band": predicted_band,
+                "band_correct": predicted_band == case.labels.overall_band,
+                "agent_total": mean_total,
+                "total_stdev": total_stdev,
+                "agent_categories": mean_categories,
+                "categories": per_cat_detail,
+                "all_within_range": all_within,
+            }
+        )
+        summarize_input.append(
+            {
+                "id": case.id,
+                "gold_band": case.labels.overall_band,
+                "gold_categories": gold_categories,
+                "agent_total": mean_total,
+                "agent_categories": mean_categories,
+            }
+        )
+
+    summary = metrics.summarize(summarize_input, thresholds)
+    summary["stability"] = {
+        "mean_total_stdev": statistics.fmean(stdevs) if stdevs else 0.0,
+        "max_total_stdev": max(stdevs) if stdevs else 0.0,
+    }
+
+    return {
+        "metadata": {
+            "provider": os.getenv("LLM_PROVIDER", "ollama"),
+            "model": os.getenv("DEFAULT_MODEL", "gemma3:4b"),
+            "n_cases": len(cases),
+            "repeat": repeat,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        },
+        "summary": summary,
+        "cases": case_reports,
+    }
+
+
+def write_report(report: dict, path: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, ensure_ascii=False)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def _print_report(report: dict) -> None:
+    meta = report["metadata"]
+    summary = report["summary"]
+    print("\n" + "=" * 78)
+    print("GOLDEN DATASET EVALUATION")
+    print("=" * 78)
+    print(f"Provider/Model : {meta['provider']} / {meta['model']}")
+    print(f"Cases          : {meta['n_cases']}   Repeats/case: {meta['repeat']}")
+    print("-" * 78)
+    print(f"{'id':<28}{'gold':<8}{'pred':<8}{'total':>8}  within-range")
+    print("-" * 78)
+    for c in report["cases"]:
+        mark = "ok" if c["band_correct"] else "MISS"
+        within = "yes" if c["all_within_range"] else "no"
+        print(
+            f"{c['id']:<28}{c['gold_band']:<8}{c['predicted_band']:<8}"
+            f"{c['agent_total']:>8.1f}  {within} [{mark}]"
+        )
+    print("-" * 78)
+    band = summary["band"]
+    print(f"Band exact accuracy   : {band['exact_accuracy']:.2%}")
+    print(f"Band within-one rate  : {band['within_one_rate']:.2%}")
+    print(f"Overall within-range  : {summary['overall_within_range_rate']:.2%}")
+    rho = summary["rank_correlation_spearman"]
+    print(f"Rank corr (Spearman)  : {'n/a' if rho is None else f'{rho:.3f}'}")
+    if meta["repeat"] > 1:
+        print(f"Mean total stdev      : {summary['stability']['mean_total_stdev']:.2f}")
+    print("\nPer-category:")
+    for cat, m in summary["categories"].items():
+        print(
+            f"  {cat:<18} within {m['within_range_rate']:.0%}  "
+            f"bias {m['mean_signed_midpoint_error']:+.1f}  "
+            f"mean-miss {m['mean_out_of_range_distance']:.1f}"
+        )
+    print("=" * 78 + "\n")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate the hiring agent against the golden dataset."
+    )
+    parser.add_argument(
+        "--golden-dir",
+        default=DEFAULT_GOLDEN_DIR,
+        help="Directory of golden *.json cases.",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        help="Runs per case (averages to smooth LLM noise).",
+    )
+    parser.add_argument(
+        "--filter", default=None, help="Only run the case with this id."
+    )
+    parser.add_argument(
+        "--out", default=None, help="Write the JSON report to this path."
+    )
+    parser.add_argument(
+        "--min-band-accuracy",
+        type=float,
+        default=None,
+        help="Exit non-zero if band exact accuracy is below this (0..1).",
+    )
+    args = parser.parse_args(argv)
+
+    cases = load_cases(args.golden_dir)
+    if args.filter:
+        cases = [c for c in cases if c.id == args.filter]
+    if not cases:
+        print("No golden cases found.", file=sys.stderr)
+        return 1
+
+    report = run(cases, repeat=args.repeat)
+    _print_report(report)
+
+    if args.out:
+        write_report(report, args.out)
+        print(f"Report written to {args.out}")
+
+    if args.min_band_accuracy is not None:
+        acc = report["summary"]["band"]["exact_accuracy"]
+        if acc < args.min_band_accuracy:
+            print(
+                f"FAIL: band accuracy {acc:.2%} < threshold {args.min_band_accuracy:.2%}",
+                file=sys.stderr,
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/score.py
+++ b/score.py
@@ -38,35 +38,30 @@ def print_evaluation_results(
         print("❌ No evaluation data available")
         return
 
-    # Calculate overall score
-    total_score = 0
-    max_score = 0
+    # Calculate overall score using the shared aggregation (single source of
+    # truth, also used by the evals framework).
+    from score_utils import aggregate_scores, MAX_BONUS
 
+    aggregate = aggregate_scores(evaluation)
+    max_score = aggregate.category_max
+
+    # Log warning if any category score was capped.
     if hasattr(evaluation, "scores") and evaluation.scores:
         for category_name, category_data in evaluation.scores.model_dump().items():
-            category_score = min(category_data["score"], category_data["max"])
-            total_score += category_score
-            max_score += category_data["max"]
-
-            # Log warning if score was capped
-            if category_score < category_data["score"]:
+            capped_score = aggregate.per_category[category_name]
+            if capped_score < category_data["score"]:
                 print(
-                    f"⚠️  Warning: {category_name} score capped from {category_data['score']} to {category_score} (max: {category_data['max']})"
+                    f"⚠️  Warning: {category_name} score capped from {category_data['score']} to {capped_score} (max: {category_data['max']})"
                 )
 
-    # Add bonus points
-    if hasattr(evaluation, "bonus_points") and evaluation.bonus_points:
-        total_score += evaluation.bonus_points.total
-
-    # Subtract deductions
-    if hasattr(evaluation, "deductions") and evaluation.deductions:
-        total_score -= evaluation.deductions.total
-
-    # Ensure total score doesn't exceed maximum possible score
-    max_possible_score = max_score + 20  # 120 (100 categories + 20 bonus)
-    if total_score > max_possible_score:
-        total_score = max_possible_score
+    # Warn if the uncapped total would have exceeded the maximum possible score.
+    if (
+        aggregate.category_total + aggregate.bonus - aggregate.deductions
+        > max_score + MAX_BONUS
+    ):
         print(f"⚠️  Warning: Total score capped at maximum possible value")
+
+    total_score = aggregate.total
 
     # Overall Score
     print(f"\n🎯 OVERALL SCORE: {total_score:.1f}/{max_score}")

--- a/score_utils.py
+++ b/score_utils.py
@@ -1,0 +1,73 @@
+"""Shared score-aggregation helpers.
+
+This is the single source of truth for turning an ``EvaluationData`` into a
+final numeric score. Both the CLI (``score.py``) and the evaluation framework
+(``evals/``) use it, so the benchmark measures exactly the number users see.
+
+Kept dependency-light (only ``models``) so it imports without pulling PyMuPDF,
+ollama, or the network.
+"""
+
+from dataclasses import dataclass
+from typing import Dict
+
+from models import EvaluationData
+
+# Category caps, mirroring the scoring criteria in
+# prompts/templates/resume_evaluation_criteria.jinja.
+CATEGORY_MAXES: Dict[str, int] = {
+    "open_source": 35,
+    "self_projects": 30,
+    "production": 25,
+    "technical_skills": 10,
+}
+
+# Mirrors evaluator.MAX_BONUS_POINTS and evaluator.MAX_FINAL_SCORE.
+MAX_BONUS = 20
+MAX_FINAL_SCORE = 120  # 100 category points + 20 bonus
+
+
+@dataclass
+class ScoreAggregate:
+    """The aggregated view of an evaluation."""
+
+    per_category: Dict[str, float]  # capped category scores
+    category_total: float  # sum of capped category scores (<= 100)
+    category_max: int  # sum of category maxima (== 100)
+    bonus: float
+    deductions: float
+    total: float  # category_total + bonus - deductions, capped
+
+
+def aggregate_scores(evaluation: EvaluationData) -> ScoreAggregate:
+    """Aggregate an ``EvaluationData`` into capped per-category scores and a total.
+
+    Each category score is capped at the category's declared ``max`` (an LLM may
+    return an out-of-bounds value). The final total is
+    ``sum(capped categories) + bonus - deductions`` capped at ``MAX_FINAL_SCORE``.
+    """
+    per_category: Dict[str, float] = {}
+    category_total = 0.0
+    category_max = 0
+
+    for name, data in evaluation.scores.model_dump().items():
+        capped = min(data["score"], data["max"])
+        per_category[name] = capped
+        category_total += capped
+        category_max += data["max"]
+
+    bonus = evaluation.bonus_points.total if evaluation.bonus_points else 0.0
+    deductions = evaluation.deductions.total if evaluation.deductions else 0.0
+
+    total = category_total + bonus - deductions
+    if total > MAX_FINAL_SCORE:
+        total = MAX_FINAL_SCORE
+
+    return ScoreAggregate(
+        per_category=per_category,
+        category_total=category_total,
+        category_max=category_max,
+        bonus=bonus,
+        deductions=deductions,
+        total=total,
+    )


### PR DESCRIPTION
# Add golden dataset & evaluation framework for agent performance (#308)

Closes #308.

## What & why

Adds a golden dataset of labeled résumés plus an evaluation runner so the agent's
scoring can be measured and compared across models (the issue's motivation:
understanding performance when swapping in ad-hoc models).

It measures at the **evaluator boundary**: each case supplies a structured
résumé (`JSONResume`) + optional GitHub data, and the runner compares the
evaluator's output against human-assigned **bands** and **per-category tolerance
ranges**. This isolates scoring quality (what changes when you swap models) from
PDF parsing, extraction, and live GitHub calls. All committed résumés are
**synthetic** (no PII, no real GitHub accounts).

## What's included

- `evals/golden/*.json` — 9 synthetic labeled résumés (3 strong / 3 medium /
  3 weak, incl. edge cases: OSS-only, production-only, tutorial-projects-only).
- `evals/run_eval.py` — runs each case through the real evaluator; reports band
  accuracy, per-category within-range rate + bias (calibration), Spearman rank
  correlation, and cross-repeat stability; writes a model-stamped JSON report.
  Flags: `--repeat`, `--filter`, `--out`, `--min-band-accuracy` (regression gate).
- `evals/metrics.py` — pure, offline metric functions.
- `evals/tests/` — offline unit + smoke + dataset-integrity tests (no LLM/network).
- `score_utils.py` — extracted score aggregation so the CLI and the eval compute
  the total identically (behavior-preserving refactor of `score.py`).
- README updates + `evals/README.md` (format, metrics, how to add cases).

## Usage

```bash
python -m evals.run_eval                 # score the dataset, print metrics
python -m evals.run_eval --repeat 3      # average runs to smooth LLM noise
LLM_PROVIDER=gemini DEFAULT_MODEL=gemini-2.0-flash python -m evals.run_eval
python -m pytest evals/tests             # offline tests, no backend needed
```

## Testing

- 54 offline tests pass; Black clean.
- Refactor verified behavior-preserving (CLI still prints the same total and cap
  warning for a sample evaluation).
- Not run against a live LLM in CI (requires an Ollama/Gemini backend); the tests
  run fully offline via a dependency-injected evaluator.

## Notes for reviewers

- Follows CONTRIBUTING: Black-formatted, offline smoke tests exercising each
  stage, issue referenced. No prompt changes, so no before/after prompt examples.
- The seed set is intentionally small and designed to be grown by contributors;
  `evals/README.md` documents the case format and how to add more.