### PR TITLE
fix: reconfigure stdout/stderr to utf-8 to prevent crash on windows

### DIFF
--- a/score.py
+++ b/score.py
@@ -3,6 +3,11 @@ import sys
 import json
 import logging
 import csv
+
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8")
+
 from pdf import PDFHandler
 from github import fetch_and_display_github_info
 from models import JSONResume, EvaluationData

--- a/score.py
+++ b/score.py
@@ -4,9 +4,11 @@ import json
 import logging
 import csv
 
-for _stream in (sys.stdout, sys.stderr):
-    if hasattr(_stream, "reconfigure"):
-        _stream.reconfigure(encoding="utf-8")
+if sys.platform == "win32":
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8")
 
 from pdf import PDFHandler
 from github import fetch_and_display_github_info


### PR DESCRIPTION
On windows hiring-agent is crashing when trying to parse the emojis from the print results to the console. This is a windows specific bug fix that should resolve it