### PR TITLE
fix: don't abort extraction when a section is validly empty

### DIFF
--- a/pdf.py
+++ b/pdf.py
@@ -288,10 +288,16 @@ class PDFHandler:
 
         for section_name in sections:
             section_data = self._extract_section_data(text_content, section_name)
+            if section_data is None:
+                logger.warning(f"🔁 Retrying {section_name} section extraction")
+                section_data = self._extract_section_data(text_content, section_name)
 
             if section_data:
                 complete_resume.update(section_data)
                 logger.debug(f"✅ Successfully extracted {section_name} section")
+            elif section_data is not None:
+                # Valid response with no content for this section (e.g. no awards)
+                logger.warning(f"⚠️ {section_name} section empty; continuing")
             else:
                 logger.error(
                     f"⚠️ Failed to extract {section_name} section. Aborting extraction to prevent partial/invalid resume data."


### PR DESCRIPTION
## Problem

When a resume has no awards (or another optional section is empty), the LLM often returns an empty JSON object `{}`. `transform_parsed_data` passes it through, and the falsy check in `_extract_all_sections_separately` treats it as an extraction failure — aborting the **entire resume** with:

```
⚠️ Failed to extract awards section. Aborting extraction to prevent partial/invalid resume data.
```

This makes scoring fail deterministically for any resume without an awards section (very common for experienced candidates), and contributes to the flaky-failure behavior several people have written about.

## Fix

Distinguish "valid but empty" (`{}`) from "failed" (`None`) in the section loop:

- empty dict → log a warning and continue with the section left empty
- `None` (LLM/JSON error) → retry once, then abort as before

## Testing

Reproduced on a real 2-page analyst resume with no awards section using the Ollama provider (qwen2.5vl:7b): extraction aborted 100% of the time before the patch, and completes with `awards: None` after it. Resumes with awards sections are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)