### PR TITLE
feat: add gemma4 model and set as default provider

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -1,5 +1,5 @@
 {
-  "default_model": "gemma3:4b",
+  "default_model": "gemma4:latest",
   "providers": {
     "ollama": {
       "base_url": "http://localhost:11434/v1",
@@ -12,6 +12,7 @@
         "qwen3:4b":    { "temperature": 0.1, "top_p": 0.4 },
         "gemma3:4b":   { "temperature": 0.1, "top_p": 0.9 },
         "gemma3:12b":  { "temperature": 0.1, "top_p": 0.9 },
+        "gemma4:latest": { "temperature": 0.1, "top_p": 0.9 },
         "mistral:7b":  { "temperature": 0.1, "top_p": 0.9 }
       }
     },


### PR DESCRIPTION
Register gemma4:latest in the Ollama provider model list and make it the default_model.