### PR TITLE
fix: load .env in config.py before env reads so DEFAULT_MODEL applies

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,9 +4,14 @@ import json
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 # Global development mode flag. Preserved here because score.py and github.py
 # import it from this module.
 DEVELOPMENT_MODE = True
+
+# Load .env before any os.getenv below, so values apply regardless of import order.
+load_dotenv(Path(__file__).parent / ".env")
 
 _CONFIG_PATH = Path(__file__).parent / "providers.json"
 

--- a/prompt.py
+++ b/prompt.py
@@ -5,12 +5,7 @@ This module contains all the prompts used by the resume evaluation system.
 Centralizing prompts here makes them easier to maintain and update.
 """
 
-import os
-from dotenv import load_dotenv
 from config import DEFAULT_MODEL, MODEL_PARAMETERS
-
-# Load environment variables (kept for any downstream os.getenv use)
-load_dotenv()
 
 # Re-exported for consumers (score.py, evaluator.py, pdf.py, github.py).
 __all__ = ["DEFAULT_MODEL", "MODEL_PARAMETERS"]


### PR DESCRIPTION
## Summary

`DEFAULT_MODEL` set in `.env` was silently ignored: `config.py` reads it via `os.getenv()` at import time, but `load_dotenv()` only ran later in `prompt.py` after `config` had already been imported. The `providers.json` default always took priority.

## Changes

- `config.py` now loads `.env` at the top of the module, before any `os.getenv`. The path is anchored to the module file (same pattern as `_CONFIG_PATH`) rather than bare `load_dotenv()`, whose cwd-based fallback misses `.env` in some instances
- `prompt.py` has the now-redundant `load_dotenv()` call removed as it is now a pure re-export shim.

Shell exported vars still take precedence (`load_dotenv` doesn't override existing environ entries).

Fixes Issue #356