### PR TITLE
docs: update README for config driven providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Since this was built, HackerRank has also shipped [AI Interviewer (Chakra)](http
 
 **On the default model:**
 
-The repo ships with `gemma3:4b` as the default because it runs locally on most laptops without any cloud API key. Actual intern resumes at HackerRank are evaluated using a top-tier Gemini model. The repo ships with a demo config, not the production one.
+The repo ships with `gemma4:latest` as the default because it runs locally on most laptops without any cloud API key. Actual intern resumes at HackerRank are evaluated using a top-tier Gemini model. The repo ships with a demo config, not the production one.
 
 ---
 
@@ -184,14 +184,13 @@ $ cp .env.example .env
 
 **Environment variables**
 
-| Variable         | Values                                      | Description                                                            |
-| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
-| `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
-| `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
+| Variable         | Values                                      | Description                                                                                                                              |
+| ---------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEFAULT_MODEL`  | for example `gemma3:4b` or `gemini-2.5-pro` | Model to use; must exist in `providers.json` — the provider is inferred from which provider lists it. Defaults to `default_model` in `providers.json`. |
+| `GEMINI_API_KEY` | string                                      | Required when using a Gemini model.                                                                                                      |
+| `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits.                                                                  |
 
-Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
+Provider mapping lives in `providers.json` — each provider declares its `base_url`, an optional API-key env var, and per-model parameters; `config.py` loads it and resolves the provider for a model. `config.py` also has a flag:
 
 ```python
 # config.py
@@ -291,6 +290,7 @@ What happens:
 │       ├── skills.jinja
 │       ├── system_message.jinja
 │       └── work.jinja
+├── providers.json
 ├── pymupdf_rag.py
 ├── requirements.txt
 ├── score.py
@@ -303,16 +303,14 @@ What happens:
 
 ### Ollama
 
-- Set `LLM_PROVIDER=ollama`
-- Set `DEFAULT_MODEL` to any pulled model, for example `gemma3:4b`
-- The provider wrapper in `models.OllamaProvider` calls `ollama.chat`
+- Set `DEFAULT_MODEL` to any pulled model listed in `providers.json`, for example `gemma3:4b`
+- Requests go through `models.OpenAICompatibleProvider` against Ollama's OpenAI-compatible endpoint (`http://localhost:11434/v1`)
 
 ### Gemini
 
-- Set `LLM_PROVIDER=gemini`
-- Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
+- Set `DEFAULT_MODEL` to a Gemini model listed in `providers.json`, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
-- The wrapper in `models.GeminiProvider` adapts responses to a unified format
+- The same `models.OpenAICompatibleProvider` wrapper is used, pointed at Gemini's OpenAI-compatible endpoint
 
 ---
 


### PR DESCRIPTION
Since #298 moved provider selection into `providers.json`, several README sections still described the old architecture. This updates them to match the code:

- **Directory layout**: added `providers.json`.
- **Configuration table**: removed the `LLM_PROVIDER` row — the variable is no longer read anywhere; the provider is inferred from `DEFAULT_MODEL` via `providers.json`. Reworded the `DEFAULT_MODEL` and `GEMINI_API_KEY` descriptions to match.
- **Provider mapping**: now correctly attributed to `providers.json` (loaded by `config.py`) instead of `prompt.py`/`models.py`.
- **Provider details**: replaced references to the removed `models.OllamaProvider` / `models.GeminiProvider` with `OpenAICompatibleProvider`, which talks to both providers over their OpenAI-compatible endpoints.
- **Default model**: `gemma3:4b` → `gemma4:latest` changed in #357.

Fixes #359 