### PR TITLE
fix: unwrap nested profile dict for GitHub CSV fields

### DIFF
--- a/transform.py
+++ b/transform.py
@@ -657,11 +657,12 @@ def transform_evaluation_response(
 
     # Extract GitHub data
     if github_data:
-        csv_row["github_repos"] = github_data.get("public_repos", 0)
-        csv_row["github_followers"] = github_data.get("followers", 0)
-        csv_row["github_following"] = github_data.get("following", 0)
-        csv_row["github_created_at"] = github_data.get("created_at", "")
-        csv_row["github_bio"] = github_data.get("bio", "")
+        profile = github_data.get("profile", {})
+        csv_row["github_repos"] = profile.get("public_repos", 0)
+        csv_row["github_followers"] = profile.get("followers", 0)
+        csv_row["github_following"] = profile.get("following", 0)
+        csv_row["github_created_at"] = profile.get("created_at", "")
+        csv_row["github_bio"] = profile.get("bio", "")
     else:
         csv_row["github_repos"] = 0
         csv_row["github_followers"] = 0


### PR DESCRIPTION
Fixes #361

## Problem
`github_repos`, `github_followers`, `github_following`, `github_created_at`, and `github_bio` in `resume_evaluations.csv` were always `0`/empty, even when GitHub data was successfully fetched and classified.

## Root cause
`transform.py`'s CSV row builder read these fields directly off `github_data`:
```python
csv_row["github_repos"] = github_data.get("public_repos", 0)
```
But `github_data` is shaped `{profile, projects, total_projects}` — the real profile fields (`public_repos`, `followers`, etc.) live nested under `github_data["profile"]`. This nesting is already handled correctly elsewhere in the same file (`convert_github_data_to_text`) and in `score.py`, just missed here.

## Fix
Unwrap `profile = github_data.get("profile", {})` before reading the 5 affected fields, consistent with the existing pattern used elsewhere in the codebase.

## Testing
Ran `score.py` against a real resume with a linked GitHub profile.
Before: `github_repos=0`, followers/following/created_at/bio all blank.
After: `github_repos=28`, all fields correctly populated, matching the console's "Found 28 repositories" output.