### PR TITLE
fix: retry transient 5xx server errors in OpenAICompatibleProvider

### DIFF
--- a/models.py
+++ b/models.py
@@ -320,6 +320,9 @@ class OpenAICompatibleProvider:
         MAX_RETRIES = 5
         BASE_DELAY = 10.0  # seconds — base for exponential backoff
         MAX_DELAY = 120.0  # cap so we never wait more than 2 minutes
+        # Transient server errors worth retrying with backoff. Unlike 429 these
+        # rarely carry a Retry-After header, so we always use exponential backoff.
+        RETRYABLE_SERVER_ERRORS = {500, 502, 503, 504}
         for attempt in range(MAX_RETRIES):
             response = requests.post(url, json=body, headers=headers, timeout=300)
 
@@ -331,6 +334,20 @@ class OpenAICompatibleProvider:
                 print(
                     f"[OpenAICompatibleProvider] Rate limit hit "
                     f"(attempt {attempt + 1}/{MAX_RETRIES}). Retrying in {sleep_time}s..."
+                )
+                time.sleep(sleep_time)
+                continue
+
+            if (
+                response.status_code in RETRYABLE_SERVER_ERRORS
+                and attempt < MAX_RETRIES - 1
+            ):
+                exp_delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                sleep_time = round(exp_delay * random.uniform(0.8, 1.2), 2)
+                print(
+                    f"[OpenAICompatibleProvider] Transient server error "
+                    f"{response.status_code} (attempt {attempt + 1}/{MAX_RETRIES}). "
+                    f"Retrying in {sleep_time}s..."
                 )
                 time.sleep(sleep_time)
                 continue


### PR DESCRIPTION
## Summary
Extends the retry loop in `OpenAICompatibleProvider.chat()` to also retry transient server errors (`500`, `502`, `503`, `504`), reusing the existing exponential-backoff-with-jitter logic.

## Problem
The loop previously only retried `429` rate limits. A transient `5xx` — e.g. Gemini's OpenAI-compatible endpoint returning `504 Deadline expired` on a larger section call — fell straight through to `response.raise_for_status()` and aborted the entire run (`models.py:338`).

## Fix
Retry `{500, 502, 503, 504}` with the same backoff used for `429`. These responses rarely carry a `Retry-After` header, so we always use exponential backoff (capped at 120s, ±20% jitter).

## Context — supersedes the Gemini 429/5xx PR cluster
This carries forward the core idea from **#285**, reimplemented against the current provider layer. When #285/#243/#247 were written, `models.py` had a dedicated Gemini SDK provider (`generate_content` / `ResourceExhausted`); that was replaced by the config-driven `OpenAICompatibleProvider` in **#298**, so those PRs target code that no longer exists. Generic `429` backoff already shipped with #298; this closes the remaining gap (transient 5xx).

Closes the intent of #243, #247, #285.

## Testing
- `python -m py_compile models.py` passes
- Logic verified by inspection: 429 path unchanged; 5xx path added before `raise_for_status()`; non-retryable statuses and the final attempt still raise as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)