### PR TITLE
feat: add Anthropic (Claude) provider via config

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -27,6 +27,16 @@
         "gemini-2.5-flash-lite": { "temperature": 0.1, "top_p": 0.9 },
         "gemini-2.5-pro":        { "temperature": 0.1, "top_p": 0.9 }
       }
+    },
+    "anthropic": {
+      "base_url": "https://api.anthropic.com/v1",
+      "api_key_env": "ANTHROPIC_API_KEY",
+      "structured_output": "json_object",
+      "models": {
+        "claude-opus-4-8":  { "temperature": 0.1, "top_p": 0.9 },
+        "claude-sonnet-5":  { "temperature": 0.1, "top_p": 0.9 },
+        "claude-haiku-4-5": { "temperature": 0.1, "top_p": 0.9 }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds an `anthropic` provider block to `providers.json` so the pipeline can run on Claude models — **no new code**. It uses Anthropic's OpenAI-compatible endpoint (`https://api.anthropic.com/v1`), so the existing config-driven `OpenAICompatibleProvider` (introduced in #298) handles it, exactly like Gemini is wired via its OpenAI-compatible endpoint.

Registers `claude-opus-4-8`, `claude-sonnet-5`, and `claude-haiku-4-5`, keyed on `ANTHROPIC_API_KEY`.

## Usage
```bash
export ANTHROPIC_API_KEY=sk-ant-...
DEFAULT_MODEL=claude-opus-4-8 ./venv/bin/python score.py resume/sample.pdf
```

## Why config, not a provider class
After #298 the provider layer is fully config-driven (`provider_for()` → `OpenAICompatibleProvider`); there's no `ModelProvider` enum or per-provider class anymore. Anthropic ships an OpenAI-compatible endpoint, so Claude access needs only a config entry.

## Verified
- `providers.json` is valid JSON
- `config.provider_for("claude-opus-4-8")` resolves `base_url`, `ANTHROPIC_API_KEY`, and `structured_output`
- `MODEL_PARAMETERS["claude-opus-4-8"]` returns params

## Note
- `structured_output` is `json_object` rather than `json_schema` — Anthropic's OpenAI-compatible layer has limited JSON-schema support, and the pipeline already cleans up JSON via `extract_json_from_response`. Worth confirming with one real run against a key.

## Supersedes
Replaces the pre-#298 Claude-provider PRs that added bespoke provider classes / CLI-SDK integrations: #205, #224, #235, #279, #303, #330, #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)