### PR TITLE
docs: update README for config-driven providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,11 @@ $ cp .env.example .env
 
 | Variable         | Values                                      | Description                                                            |
 | ---------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
-| `LLM_PROVIDER`   | `ollama` or `gemini`                        | Chooses provider. Defaults to Ollama.                                  |
-| `DEFAULT_MODEL`  | for example `gemma4:latest` or `gemini-2.5-pro` | Model name passed to the provider.                                     |
-| `GEMINI_API_KEY` | string                                      | Required when `LLM_PROVIDER=gemini`.                                   |
+| `DEFAULT_MODEL`  | for example `gemma4:latest` or `gemini-2.5-pro` | Model to use; must exist in `providers.json` — the provider is inferred from which provider lists it. Defaults to `default_model` in `providers.json`. |
+| `GEMINI_API_KEY` | string                                      | Required when using a Gemini model.                                   |
 | `GITHUB_TOKEN`   | optional                                    | Inherits from your shell environment, improves GitHub API rate limits. |
 
-Provider mapping lives in `prompt.py` and `models.py`. The `config.py` file has a single flag:
+Provider mapping lives in `providers.json` — each provider declares its `base_url`, an optional API-key env var, and per-model parameters; `config.py` loads it and resolves the provider for a model. `config.py` also has a flag:
 
 ```python
 # config.py
@@ -291,6 +290,7 @@ What happens:
 │       ├── skills.jinja
 │       ├── system_message.jinja
 │       └── work.jinja
+├── providers.json
 ├── pymupdf_rag.py
 ├── requirements.txt
 ├── score.py
@@ -303,16 +303,14 @@ What happens:
 
 ### Ollama
 
-- Set `LLM_PROVIDER=ollama`
-- Set `DEFAULT_MODEL` to any pulled model, for example `gemma4:latest`
-- The provider wrapper in `models.OllamaProvider` calls `ollama.chat`
+- Set `DEFAULT_MODEL` to any pulled model listed in `providers.json`, for example `gemma4:latest`
+- Requests go through `models.OpenAICompatibleProvider` against Ollama's OpenAI-compatible endpoint (`http://localhost:11434/v1`)
 
 ### Gemini
 
-- Set `LLM_PROVIDER=gemini`
-- Set `DEFAULT_MODEL` to a supported Gemini model, for example `gemini-2.0-flash`
+- Set `DEFAULT_MODEL` to a Gemini model listed in `providers.json`, for example `gemini-2.0-flash`
 - Provide `GEMINI_API_KEY`
-- The wrapper in `models.GeminiProvider` adapts responses to a unified format
+- The same `models.OpenAICompatibleProvider` wrapper is used, pointed at Gemini's OpenAI-compatible endpoint
 
 ---
 


### PR DESCRIPTION
## Summary
Brings the README in line with the config-driven provider architecture from #298. Reconciled onto current `main` (retains the `gemma4:latest` default already merged in #363).

- **Env-var table**: drop the `LLM_PROVIDER` row — the variable is no longer read anywhere; the provider is inferred from `DEFAULT_MODEL` via `providers.json`. Reworded the `DEFAULT_MODEL` and `GEMINI_API_KEY` descriptions.
- **Provider mapping**: attributed to `providers.json` (loaded by `config.py`) instead of the old `prompt.py` / `models.py`.
- **Directory layout**: added `providers.json`.
- **Provider details**: replaced the deleted `models.OllamaProvider` / `models.GeminiProvider` references with the unified `models.OpenAICompatibleProvider`.

## Credit
Reconciled version of #360 by @thejamesgore (that PR conflicted with the README changes since merged in #363). Credited via `Co-Authored-By`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)