### PR TITLE
fix(config): call load_dotenv() in config.py and add gemini-flash-lite-latest alias

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,6 +3,9 @@
 import json
 import os
 from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Global development mode flag. Preserved here because score.py and github.py
 # import it from this module.

--- a/providers.json
+++ b/providers.json
@@ -25,7 +25,8 @@
         "gemini-2.0-flash-lite": { "temperature": 0.1, "top_p": 0.9 },
         "gemini-2.5-flash":      { "temperature": 0.1, "top_p": 0.9 },
         "gemini-2.5-flash-lite": { "temperature": 0.1, "top_p": 0.9 },
-        "gemini-2.5-pro":        { "temperature": 0.1, "top_p": 0.9 }
+        "gemini-2.5-pro":        { "temperature": 0.1, "top_p": 0.9 },
+        "gemini-flash-lite-latest": { "temperature": 0.1, "top_p": 0.9 }
       }
     }
   }


### PR DESCRIPTION
## Problem
1. `config.py` evaluates `os.getenv("DEFAULT_MODEL", ...)` at import time, but `load_dotenv()` was only called later in `prompt.py`. As a result, `.env` settings were ignored when importing `config.py` directly.
2. New Gemini API keys hit `404 Not Found` errors on deprecated snapshot model names (`gemini-2.5-flash`).

## Solution
1. Add `from dotenv import load_dotenv` and `load_dotenv()` at the top of `config.py`.
2. Add `gemini-flash-lite-latest` model alias to `providers.json`.

## Testing
- Verified `.env` variables load automatically on `config.py` import.
- Successfully ran `score.py` using `DEFAULT_MODEL=gemini-flash-lite-latest`.