### PR TITLE
test: add provider config smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 **/*.pyc
 resume/*.pdf
 run/*.pdf
-test_*.py
 cache/
 resume_evaluations.csv
 resume_evaluations_*.csv

--- a/github.py
+++ b/github.py
@@ -367,7 +367,7 @@ def generate_projects_json(
         )
 
         print(
-            f"🤖 Using LLM to select top 5 projects from {len(projects)} repositories..."
+            f"🤖 Using LLM to select top 7 projects from {len(projects)} repositories..."
         )
 
         # Initialize the LLM provider

--- a/test_config.py
+++ b/test_config.py
@@ -1,0 +1,84 @@
+import importlib
+import os
+
+import config
+
+
+def test_default_model_is_configured():
+    assert config.DEFAULT_MODEL in config.MODEL_PARAMETERS
+
+
+def test_default_model_env_override():
+    original = os.environ.get("DEFAULT_MODEL")
+    os.environ["DEFAULT_MODEL"] = "qwen3:4b"
+    try:
+        importlib.reload(config)
+        assert config.DEFAULT_MODEL == "qwen3:4b"
+    finally:
+        if original is None:
+            os.environ.pop("DEFAULT_MODEL", None)
+        else:
+            os.environ["DEFAULT_MODEL"] = original
+        importlib.reload(config)
+
+
+def test_model_parameters_flat_map():
+    assert config.MODEL_PARAMETERS["gemma4:latest"] == {
+        "temperature": 0.1,
+        "top_p": 0.9,
+    }
+    assert config.MODEL_PARAMETERS["qwen3:4b"] == {"temperature": 0.1, "top_p": 0.4}
+    assert set(config.MODEL_PARAMETERS["gemma4:latest"]) == {"temperature", "top_p"}
+
+
+def test_provider_for_ollama_keyless():
+    cfg = config.provider_for("gemma4:latest")
+    assert cfg["base_url"] == "http://localhost:11434/v1"
+    assert cfg["api_key"] is None
+    assert cfg["structured_output"] == "json_schema"
+    assert cfg["extra_body"] == {"num_ctx": 32768}
+
+
+def test_provider_for_gemini_reads_key():
+    original = os.environ.get("GEMINI_API_KEY")
+    os.environ["GEMINI_API_KEY"] = "test-key-123"
+    try:
+        cfg = config.provider_for("gemini-2.5-pro")
+        assert cfg["api_key"] == "test-key-123"
+        assert cfg["base_url"] == "https://generativelanguage.googleapis.com/v1beta/openai"
+        assert cfg["structured_output"] == "json_schema"
+    finally:
+        if original is None:
+            os.environ.pop("GEMINI_API_KEY", None)
+        else:
+            os.environ["GEMINI_API_KEY"] = original
+
+
+def test_provider_for_missing_key_raises():
+    original = os.environ.get("GEMINI_API_KEY")
+    os.environ.pop("GEMINI_API_KEY", None)
+    try:
+        config.provider_for("gemini-2.5-pro")
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "GEMINI_API_KEY" in str(e)
+    finally:
+        if original is not None:
+            os.environ["GEMINI_API_KEY"] = original
+
+
+def test_unknown_model_raises_with_list():
+    try:
+        config.provider_for("no-such-model")
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "no-such-model" in str(e)
+        assert "gemma4:latest" in str(e)
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"PASS {name}")
+    print("ALL PASS")

--- a/test_providers.py
+++ b/test_providers.py
@@ -1,0 +1,110 @@
+from unittest.mock import MagicMock, patch
+
+from models import OpenAICompatibleProvider
+
+
+def _mock_response(payload=None, status_code=200, headers=None):
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.json.return_value = payload or {
+        "choices": [{"message": {"content": '{"ok": true}'}}]
+    }
+    return response
+
+
+def test_json_schema_response_format():
+    response = _mock_response()
+    with patch("requests.post", return_value=response) as post:
+        provider = OpenAICompatibleProvider(
+            base_url="http://localhost:11434/v1",
+            structured_output="json_schema",
+        )
+        result = provider.chat(
+            model="gemma4:latest",
+            messages=[{"role": "user", "content": "hi"}],
+            options={"temperature": 0.1, "top_p": 0.9},
+            format={"type": "object"},
+        )
+
+    body = post.call_args.kwargs["json"]
+    assert body["model"] == "gemma4:latest"
+    assert body["temperature"] == 0.1
+    assert body["top_p"] == 0.9
+    assert body["response_format"]["type"] == "json_schema"
+    assert body["response_format"]["json_schema"]["schema"] == {"type": "object"}
+    assert result == {"message": {"role": "assistant", "content": '{"ok": true}'}}
+
+
+def test_json_object_response_format():
+    response = _mock_response()
+    with patch("requests.post", return_value=response) as post:
+        provider = OpenAICompatibleProvider(
+            base_url="https://example.com/v1",
+            structured_output="json_object",
+        )
+        provider.chat(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            format={"type": "object"},
+        )
+
+    body = post.call_args.kwargs["json"]
+    assert body["response_format"] == {"type": "json_object"}
+
+
+def test_structured_output_none_omits_response_format():
+    response = _mock_response()
+    with patch("requests.post", return_value=response) as post:
+        provider = OpenAICompatibleProvider(
+            base_url="https://example.com/v1",
+            structured_output="none",
+        )
+        provider.chat(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            format={"type": "object"},
+        )
+
+    body = post.call_args.kwargs["json"]
+    assert "response_format" not in body
+
+
+def test_extra_body_and_authorization_header():
+    response = _mock_response()
+    with patch("requests.post", return_value=response) as post:
+        provider = OpenAICompatibleProvider(
+            base_url="https://example.com/v1/",
+            api_key="secret",
+            extra_body={"num_ctx": 32768},
+        )
+        provider.chat(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert post.call_args.args[0] == "https://example.com/v1/chat/completions"
+    assert post.call_args.kwargs["json"]["num_ctx"] == 32768
+    assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer secret"
+
+
+def test_unexpected_response_shape_raises():
+    response = _mock_response(payload={"unexpected": True})
+    with patch("requests.post", return_value=response):
+        provider = OpenAICompatibleProvider(base_url="https://example.com/v1")
+        try:
+            provider.chat(
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+            assert False, "expected ValueError"
+        except ValueError as e:
+            assert "Unexpected response shape" in str(e)
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"PASS {name}")
+    print("ALL PASS")

--- a/transform.py
+++ b/transform.py
@@ -1,5 +1,4 @@
 from typing import Dict, List, Optional
-import pdb
 from models import JSONResume
 
 


### PR DESCRIPTION
## Summary
- Add plain-assert smoke tests for provider config resolution and OpenAI-compatible request shaping
- Allow `test_*.py` files to be tracked
- Fix a misleading GitHub project selection log message
- Remove an unused debugger import

## Verification
- `python3 test_config.py`
- `python3 test_providers.py`
- `python3 -m compileall -q .`
